### PR TITLE
Refactor datetime display and reservation scoping

### DIFF
--- a/app/controllers/host/reservations_controller.rb
+++ b/app/controllers/host/reservations_controller.rb
@@ -2,8 +2,7 @@ class Host::ReservationsController < ApplicationController
   before_action :find_reservation, only: [:edit, :update]
 
   def index
-    @reservations = policy_scope([:host, Reservation.for_host])
-                    .includes(:user, :cookoon)
+    @reservations = policy_scope([:host, Reservation]).includes(:user, :cookoon)
     @cookoons = current_user.cookoons
   end
 

--- a/app/controllers/host/reservations_controller.rb
+++ b/app/controllers/host/reservations_controller.rb
@@ -2,7 +2,8 @@ class Host::ReservationsController < ApplicationController
   before_action :find_reservation, only: [:edit, :update]
 
   def index
-    @reservations = policy_scope([:host, Reservation])
+    @reservations = policy_scope([:host, Reservation.for_host])
+                    .includes(:user, :cookoon)
     @cookoons = current_user.cookoons
   end
 

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -3,7 +3,8 @@ class ReservationsController < ApplicationController
   before_action :find_reservation, only: [:edit, :update, :show]
 
   def index
-    @reservations = policy_scope(Reservation)
+    @reservations = policy_scope(Reservation.for_tenant)
+                    .includes(cookoon: :photo_files)
   end
 
   def show

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -3,8 +3,7 @@ class ReservationsController < ApplicationController
   before_action :find_reservation, only: [:edit, :update, :show]
 
   def index
-    @reservations = policy_scope(Reservation.for_tenant)
-                    .includes(cookoon: :photo_files)
+    @reservations = policy_scope(Reservation).includes(cookoon: :photo_files)
   end
 
   def show

--- a/app/helpers/datetime_helper.rb
+++ b/app/helpers/datetime_helper.rb
@@ -1,0 +1,16 @@
+module DatetimeHelper
+  def display_datetime_for(datetime, attrs = {})
+    datetime_array = [display_date_for(datetime)]
+    datetime_array << attrs[:join_expression]
+    datetime_array << display_time_for(datetime)
+    datetime_array.join(' ')
+  end
+
+  def display_date_for(datetime)
+    l(datetime, format: '%-d %B %Y')
+  end
+
+  def display_time_for(datetime)
+    l(datetime, format: '%kh%M')
+  end
+end

--- a/app/helpers/host_reservation_card_helper.rb
+++ b/app/helpers/host_reservation_card_helper.rb
@@ -19,7 +19,7 @@ module HostReservationCardHelper
     private
 
     attr_accessor :view, :reservation, :user
-    delegate :link_to, :content_tag, :image_tag, :cl_image_tag, :safe_join, to: :view
+    delegate :link_to, :content_tag, :image_tag, :cl_image_tag, :safe_join, :display_date_for, :display_time_for, to: :view
 
     def infos
       content = safe_join([user_picture, user_infos, status])
@@ -36,8 +36,8 @@ module HostReservationCardHelper
 
     def user_infos
       user_name = content_tag(:p, user.full_name)
-      date = content_tag(:p, reservation.date.strftime('%d %B %Y'))
-      duration = content_tag(:p, "#{reservation.date.hour}h pour #{reservation.duration}h")
+      date = content_tag(:p, display_date_for(reservation.date))
+      duration = content_tag(:p, "#{display_time_for(reservation.date)} pour #{reservation.duration}h")
       content = safe_join([user_name, date, duration])
       content_tag(:div, content, class: 'infos-block')
     end

--- a/app/helpers/host_reservation_card_helper.rb
+++ b/app/helpers/host_reservation_card_helper.rb
@@ -5,6 +5,8 @@ module HostReservationCardHelper
 
   class HostReservationCard
     include Rails.application.routes.url_helpers
+    include ActionView::Helpers::TranslationHelper
+    include DatetimeHelper
 
     def initialize(view, reservation)
       @view, @reservation = view, reservation
@@ -19,7 +21,7 @@ module HostReservationCardHelper
     private
 
     attr_accessor :view, :reservation, :user
-    delegate :link_to, :content_tag, :image_tag, :cl_image_tag, :safe_join, :display_date_for, :display_time_for, to: :view
+    delegate :link_to, :content_tag, :image_tag, :cl_image_tag, :safe_join, to: :view
 
     def infos
       content = safe_join([user_picture, user_infos, status])

--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -1,8 +1,4 @@
 module ReservationsHelper
-  def display_datetime_for(reservation)
-    reservation.date.strftime('%d/%m/%Y à %H:%M')
-  end
-
   def display_duration_for(reservation)
     "#{reservation.duration} heures"
   end

--- a/app/helpers/user_reservation_card_helper.rb
+++ b/app/helpers/user_reservation_card_helper.rb
@@ -20,7 +20,7 @@ module UserReservationCardHelper
     private
 
     attr_accessor :view, :reservation
-    delegate :link_to, :content_tag, :image_tag, :cl_image_tag, :safe_join, :safe_picture_tag_for_reservations_index, :cl_image_path, to: :view
+    delegate :link_to, :content_tag, :image_tag, :cl_image_tag, :safe_join, :safe_picture_tag_for_reservations_index, :cl_image_path, :display_datetime_for, to: :view
 
     def header
       content = safe_join([header_infos, header_status])
@@ -37,7 +37,7 @@ module UserReservationCardHelper
     end
 
     def details
-      content_tag(:p, "#{reservation.date.strftime('%d %B %Y')} . à #{reservation.date.hour}h . pour #{reservation.duration}h")
+      content_tag(:p, "#{display_datetime_for(reservation.date, join_expression: '. à')} . pour #{reservation.duration}h")
     end
 
     def header_status

--- a/app/helpers/user_reservation_card_helper.rb
+++ b/app/helpers/user_reservation_card_helper.rb
@@ -5,6 +5,8 @@ module UserReservationCardHelper
 
   class UserReservationCard
     include Rails.application.routes.url_helpers
+    include ActionView::Helpers::TranslationHelper
+    include DatetimeHelper
 
     def initialize(view, reservation)
       @view, @reservation = view, reservation
@@ -20,7 +22,7 @@ module UserReservationCardHelper
     private
 
     attr_accessor :view, :reservation
-    delegate :link_to, :content_tag, :image_tag, :cl_image_tag, :safe_join, :safe_picture_tag_for_reservations_index, :cl_image_path, :display_datetime_for, to: :view
+    delegate :link_to, :content_tag, :image_tag, :cl_image_tag, :safe_join, :safe_picture_tag_for_reservations_index, :cl_image_path, to: :view
 
     def header
       content = safe_join([header_infos, header_status])

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -9,9 +9,14 @@ class Reservation < ApplicationRecord
 
   enum status: %i[pending paid accepted refused cancelled ongoing passed]
 
-  scope :for_tenant, -> { where.not(status: :pending).order(date: :asc) }
+  scope :for_tenant, (lambda do
+    where(status: %i[paid accepted refused cancelled ongoing passed])
+    .order(date: :asc)
+  end)
+
   scope :for_host, (lambda do
-    where(status: %i[paid refused passed ongoing accepted]).order(date: :asc)
+    where(status: %i[paid accepted refused ongoing passed])
+    .order(date: :asc)
   end)
 
   def host_cookoon_fee_rate

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -9,15 +9,8 @@ class Reservation < ApplicationRecord
 
   enum status: %i[pending paid accepted refused cancelled ongoing passed]
 
-  scope :for_tenant, (lambda do
-    where(status: %i[paid accepted refused cancelled ongoing passed])
-    .order(date: :asc)
-  end)
-
-  scope :for_host, (lambda do
-    where(status: %i[paid accepted refused ongoing passed])
-    .order(date: :asc)
-  end)
+  scope :for_tenant, -> { where(status: %i[paid accepted refused cancelled ongoing passed]).order(date: :asc) }
+  scope :for_host, -> { where(status: %i[paid accepted refused ongoing passed]).order(date: :asc) }
 
   def host_cookoon_fee_rate
     0.05

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -7,7 +7,12 @@ class Reservation < ApplicationRecord
 
   validates :price_cents, presence: true
 
-  enum status: [ :pending, :paid, :accepted, :refused, :cancelled, :ongoing, :passed ]
+  enum status: %i[pending paid accepted refused cancelled ongoing passed]
+
+  scope :for_tenant, -> { where.not(status: :pending).order(date: :asc) }
+  scope :for_host, (lambda do
+    where(status: %i[paid refused passed ongoing accepted]).order(date: :asc)
+  end)
 
   def host_cookoon_fee_rate
     0.05

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -9,8 +9,9 @@ class Reservation < ApplicationRecord
 
   enum status: %i[pending paid accepted refused cancelled ongoing passed]
 
-  scope :for_tenant, -> { where(status: %i[paid accepted refused cancelled ongoing passed]).order(date: :asc) }
-  scope :for_host, -> { where(status: %i[paid accepted refused ongoing passed]).order(date: :asc) }
+  scope :displayable, -> { where.not(status: :pending).order(date: :asc) }
+  scope :for_tenant, ->(user) { where(user: user) }
+  scope :for_host, ->(user) { where(cookoon: user.cookoons) }
 
   def host_cookoon_fee_rate
     0.05

--- a/app/policies/host/reservation_policy.rb
+++ b/app/policies/host/reservation_policy.rb
@@ -10,7 +10,7 @@ class Host::ReservationPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       # here scope is an array because of namespacing
-      scope.last.includes(:user, :cookoon).where(status: [:paid, :refused, :passed, :ongoing, :accepted]).where(cookoon: user.cookoons)
+      scope.last.where(cookoon: user.cookoons)
     end
   end
 end

--- a/app/policies/host/reservation_policy.rb
+++ b/app/policies/host/reservation_policy.rb
@@ -10,7 +10,7 @@ class Host::ReservationPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       # here scope is an array because of namespacing
-      scope.last.where(cookoon: user.cookoons)
+      scope.last.for_host(user).displayable
     end
   end
 end

--- a/app/policies/reservation_policy.rb
+++ b/app/policies/reservation_policy.rb
@@ -14,7 +14,7 @@ class ReservationPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      scope.where(user: user)
+      scope.for_tenant(user).displayable
     end
   end
 end

--- a/app/policies/reservation_policy.rb
+++ b/app/policies/reservation_policy.rb
@@ -14,7 +14,7 @@ class ReservationPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      scope.where.not(status: :pending).includes(cookoon: :photo_files).where(user: user)
+      scope.where(user: user)
     end
   end
 end

--- a/app/views/host/reservations/_cookoon_infos.html.slim
+++ b/app/views/host/reservations/_cookoon_infos.html.slim
@@ -4,4 +4,4 @@
   .reservation-infos
     p
       span.reservation-title = "#{reservation.user.full_name} (status: #{reservation.status})"
-    p = "#{reservation.date.strftime('%d %B %Y')} - #{reservation.duration} H"
+    p = "#{display_date_for(reservation.date)} - #{reservation.duration} H"

--- a/app/views/host/reservations/_user_infos.html.erb
+++ b/app/views/host/reservations/_user_infos.html.erb
@@ -12,6 +12,6 @@
         <%= reservation.user.full_name %>
       </span>
     </p>
-    <p><%= "#{reservation.date.strftime('%d %B %Y')} - #{reservation.duration} H" %></p>
+    <p><%= "#{display_datetime_for(reservation.date)} - #{reservation.duration} H" %></p>
   </div>
 </div>

--- a/app/views/paiements/new.html.erb
+++ b/app/views/paiements/new.html.erb
@@ -7,7 +7,7 @@
 
   <b>Votre location :</b>
   <br><br>
-  <p>le <b><%= display_datetime_for(@reservation) %></b> pour <b><%= display_duration_for(@reservation) %></b></p>
+  <p>le <b><%= display_datetime_for(@reservation.date) %></b> pour <b><%= display_duration_for(@reservation) %></b></p>
 
   <div class="light-padded">
     <div class="flex-container">

--- a/app/views/reservations/edit.html.erb
+++ b/app/views/reservations/edit.html.erb
@@ -5,7 +5,7 @@
 <div class="container">
   <div class="reservation-details-card reservation-details-card-blue">
     <p><%= @reservation.cookoon.name.upcase %></p>
-    <p><%= "#{@reservation.date.strftime('%d %B %Y')} . à #{@reservation.date.hour}h . pour #{@reservation.duration}h" %></p>
+    <p><%= "#{display_datetime_for(@reservation.date, join_expression: '. à')} . pour #{@reservation.duration}h" %></p>
     <p><%= "#{@reservation.cookoon.category} - #{@reservation.cookoon.address} chez #{@reservation.cookoon.user.full_name}" %></p>
     <div class="text-center">
       <i class="fa fa-circle" aria-hidden="true"></i>

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -5,7 +5,7 @@
 <div class="container">
   <div class="reservation-details-card reservation-details-card-grey">
     <p><%= @reservation.cookoon.name.upcase %></p>
-    <p><%= "#{@reservation.date.strftime('%d %B %Y')} . à #{@reservation.date.hour}h . pour #{@reservation.duration}h" %></p>
+    <p><%= "#{display_datetime_for(@reservation.date, join_expression: '. à')} . pour #{@reservation.duration}h" %></p>
     <p><%= "#{@reservation.cookoon.category} - #{@reservation.cookoon.address} chez #{@reservation.cookoon.user.full_name}" %></p>
     <div class="text-center">
       <i class="fa fa-circle" aria-hidden="true"></i>


### PR DESCRIPTION
had to refactor datetime display through the application, now consistent and localized

refactor scoping with this logic:
- tenant and host scoping in the model, so behaviour is centralised
- left only specific policy scoping in policy files
- moved view-based includes back to view, because you could use policy scoping
  in other views, with different includes needed

applyed a simple date ordering in tenant and host scopes, but this logic will be
reusable when business wants to fine tune tenant and host displays