### PR TITLE
change border-sizing from border-box (default) to content-box

### DIFF
--- a/app/views/cookoons/index.slim
+++ b/app/views/cookoons/index.slim
@@ -6,5 +6,5 @@ div class=classnames(container: desktop_view?)
       = render 'reservations/search_recap', reservation: @reservation
     .row
       - @cookoons.each do |cookoon|
-        .col-12.col-md-6
+        .col-12.col-md-6 style="box-sizing: content-box"
           = render 'card', cookoon: cookoon


### PR DESCRIPTION
change border-sizing from border-box (default) to content-box in order to make the box edge-to-edge on phones