### PR TITLE
Admin routes controller view

### DIFF
--- a/app/controllers/admin/cookoons_controller.rb
+++ b/app/controllers/admin/cookoons_controller.rb
@@ -1,17 +1,19 @@
 module Admin
   class CookoonsController < ApplicationController
-    before_action :require_admin
+    # not necessary because it is specified directly in routes
+    # before_action :require_admin
+    before_action :find_cookoon, only: %i[edit update]
 
     def index
-      @cookoons = Cookoon.all
+      @cookoons_approved = cookoons.where(status: "approved")
+      @cookoons_suspended = cookoons.where(status: "suspended")
+      @cookoons_under_review = cookoons.where(status: "under_review")
     end
 
     def edit
-      @cookoon = Cookoon.find(params[:id])
     end
 
     def update
-      @cookoon = Cookoon.find(params[:id])
       if @cookoon.update(cookoon_params)
         redirect_to admin_cookoons_path, notice: 'Le Cookoon a été édité !'
       else
@@ -30,8 +32,17 @@ module Admin
       )
     end
 
-    def require_admin
-      current_user.admin == true
+    # def require_admin
+    #   current_user.admin == true
+    # end
+
+    def find_cookoon
+      @cookoon = Cookoon.find(params[:id]).decorate
+      authorize @cookoon, policy_class: Admin::CookoonPolicy
+    end
+
+    def cookoons
+      policy_scope([:admin, Cookoon]).includes(:user)
     end
 
   end

--- a/app/policies/admin/cookoon_policy.rb
+++ b/app/policies/admin/cookoon_policy.rb
@@ -1,0 +1,15 @@
+class Admin::CookoonPolicy < ApplicationPolicy
+  def create?
+    # true
+  end
+
+  def update?
+    user.admin == true
+  end
+
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/cookoon_policy.rb
+++ b/app/policies/cookoon_policy.rb
@@ -8,7 +8,7 @@ class CookoonPolicy < ApplicationPolicy
   end
 
   def update?
-    record.user == user || user.admin?
+    record.user
   end
 
   class Scope < Scope


### PR DESCRIPTION
- add pundit policy for admin/cookoons (app/policies/admin/cookoon_policy.rb)
- update admin cookoons controller to use admin policy for cookoon (app/controllers/admin/cookoons_controller.rb) to use the right policy (app/policies/admin/cookoon_policy.rb)
- rollback of pundit authorization in cookoon policy (app/policies/cookoon_policy.rb) because admin cookoons controller has now his own policy (app/policies/admin/cookoon_policy.rb)
