### PR TITLE
Payment in three times part one

### DIFF
--- a/.forestadmin-schema.json
+++ b/.forestadmin-schema.json
@@ -2196,6 +2196,21 @@
       "widget": null,
       "validations": []
     }, {
+      "field": "stripe_services_id",
+      "type": "String",
+      "default_value": null,
+      "enums": null,
+      "integration": null,
+      "is_filterable": true,
+      "is_read_only": false,
+      "is_required": false,
+      "is_sortable": true,
+      "is_virtual": false,
+      "reference": null,
+      "inverse_of": null,
+      "widget": null,
+      "validations": []
+    }, {
       "field": "services",
       "type": ["Number"],
       "default_value": null,

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -5,17 +5,18 @@ class PaymentsController < ApplicationController
   def secret
     # payment = Reservation::Payment.new(@reservation.object)
     # if payment.create_or_retrieve_and_update
-    payment = Reservation::Payment.new(@reservation.object, options = { capture_method: 'manual'})
-    if payment.create_or_retrieve_and_update(:stripe_charge_id)
-      @intent_secret_json = {client_secret: payment.return_stripe_client_secret}.to_json
-    else
-      flash.alert = payment.displayable_errors
-      redirect_to new_reservation_payment_path(payment.payable)
-    end
+    payment_cookoon = Reservation::Payment.new(@reservation.object, options = { capture_method: 'manual', charge_amount_cents: @reservation.object.cookoon_price_cents})
+    proceed_payment(payment_cookoon, :stripe_charge_id)
+  end
+
+  def secret_services
+    payment_services = Reservation::Payment.new(@reservation.object, options = { capture_method: 'automatic', charge_amount_cents: @reservation.object.services_with_tax_cents})
+    proceed_payment(payment_services, :stripe_services_id)
   end
 
   def new
     @url_intent_secret = "/reservations/#{@reservation.id}/payments/secret.json"
+    @url_intent_secret_services = "/reservations/#{@reservation.id}/payments/secret_services.json"
     @credit_cards = current_user.credit_cards
     @cookoon = @reservation.cookoon.decorate
 
@@ -23,14 +24,28 @@ class PaymentsController < ApplicationController
   end
 
   def create
-    payment = Reservation::Payment.new(@reservation.object)
-    if payment.charge
-      @reservation.notify_users_after_payment
-      redirect_to new_reservation_message_path(@reservation)
-    else
-      flash.alert = "Une erreur est survenue, néanmoins votre demande de paiement est bien effective. Veuillez contacter notre service d'aide"
-      redirect_to home_path
+    # payment = Reservation::Payment.new(@reservation.object)
+    payment = @reservation.payment
+    if @reservation.services_selected? || @reservation.cookoon_selected?
+      if payment.charge
+        @reservation.notify_users_after_payment
+        redirect_to new_reservation_message_path(@reservation)
+      else
+        flash.alert = "Une erreur est survenue, néanmoins votre demande de paiement est bien effective. Veuillez contacter notre service d'aide"
+        redirect_to home_path
+      end
+    elsif @reservation.accepted?
+      if payment.pay_services
+        # TO DO ALICE : notify user after payment by mail
+        # @reservation.notify_users_after_payment
+        flash.notice = "Votre paiement a bien été effectué"
+        redirect_to home_path
+      else
+        flash.alert = "Une erreur est survenue, néanmoins votre demande de paiement est bien effective. Veuillez contacter notre service d'aide"
+        redirect_to home_path
+      end
     end
+
     # if payment.proceed
     #   @reservation.notify_users_after_payment
     #   redirect_to new_reservation_message_path(@reservation)
@@ -64,5 +79,14 @@ class PaymentsController < ApplicationController
   def find_cookoon
     @cookoon = Cookoon.find(params[:cookoon_id])
     @reservation.select_cookoon(@cookoon)
+  end
+
+  def proceed_payment(payment, stripe_intent)
+    if payment.create_or_retrieve_and_update(stripe_intent)
+      @stripe_intent_secret_json = {client_secret: payment.return_stripe_client_secret}.to_json
+    else
+      flash.alert = payment.displayable_errors
+      redirect_to new_reservation_payment_path(payment.payable)
+    end
   end
 end

--- a/app/models/concerns/reservation_state_machine.rb
+++ b/app/models/concerns/reservation_state_machine.rb
@@ -10,10 +10,11 @@ module ReservationStateMachine
       state :menu_selected
       state :services_selected
       state :charged
-      state :quotation_asked
-      state :quotation_proposed
       state :accepted
       state :services_paid
+      state :quotation_asked
+      state :quotation_proposed
+      state :quotation_accepted
       state :refused
       state :cancelled
       state :ongoing
@@ -50,12 +51,16 @@ module ReservationStateMachine
         transitions from: :services_selected, to: :quotation_asked
       end
 
-      event :propose_quote do
+      event :propose_quotation do
         transitions from: :quotation_asked, to: :quotation_proposed
       end
 
       event :accept do
-        transitions from: [:charged, :quotation_proposed], to: :accepted
+        transitions from: [:charged], to: :accepted
+      end
+
+      event :accept_quotation do
+        transitions from: [:quotation_proposed], to: :quotation_accepted
       end
 
       event :refuse do

--- a/app/models/concerns/reservation_state_machine.rb
+++ b/app/models/concerns/reservation_state_machine.rb
@@ -13,6 +13,7 @@ module ReservationStateMachine
       state :quotation_asked
       state :quotation_proposed
       state :accepted
+      state :services_paid
       state :refused
       state :cancelled
       state :ongoing
@@ -39,6 +40,10 @@ module ReservationStateMachine
 
       event :charge do
         transitions from: :services_selected, to: :charged
+      end
+
+      event :pay_services do
+        transitions from: :accepted, to: :services_paid
       end
 
       event :ask_quotation do

--- a/app/models/concerns/stripe/chargeable.rb
+++ b/app/models/concerns/stripe/chargeable.rb
@@ -83,7 +83,7 @@ module Stripe
 
     def intent_attributes_creation
       {
-        amount: charge_amount_cents,
+        amount: options[:charge_amount_cents],
         currency: 'eur',
         customer: stripe_customer.id,
         description: intent_description,
@@ -110,7 +110,7 @@ module Stripe
 
     def intent_attributes_update
       {
-        amount: charge_amount_cents,
+        amount: options[:charge_amount_cents],
         currency: 'eur',
         customer: stripe_customer.id,
         description: intent_description,

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -58,7 +58,7 @@ class Payment
   # def after_proceed; end
 
   def charge_needed?
-    charge_amount_cents.positive?
+    options[:charge_amount_cents].positive?
   end
 
   # def charge_amount_cents

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -146,7 +146,8 @@ class Reservation < ApplicationRecord
 
   def services_need_update?
     return unless saved_change_to_aasm_state?
-    saved_change_to_aasm_state.last == 'charged'
+    # saved_change_to_aasm_state.last == 'charged'
+    saved_change_to_aasm_state.last == 'services_paid'
   end
 
   def update_services

--- a/app/models/reservation/payment.rb
+++ b/app/models/reservation/payment.rb
@@ -7,15 +7,19 @@ class Reservation
       reservation.charge! if errors.empty?
     end
 
+    def pay_services
+      reservation.pay_services! if errors.empty?
+    end
+
     private
 
     # def should_capture?
     #   ActiveModel::Type::Boolean.new.cast(options[:capture]) || false
     # end
 
-    def charge_amount_cents
-      reservation.business? ? reservation.total_price_cents : reservation.total_with_tax_cents
-    end
+    # def charge_amount_cents
+    #   reservation.business? ? reservation.total_price_cents : reservation.total_with_tax_cents
+    # end
 
     def intent_description
       "Paiement pour #{reservation.cookoon.name}"
@@ -24,7 +28,7 @@ class Reservation
     def intent_metadata
       {
         reservation_id: reservation.id,
-        reservation_price: charge_amount_cents,
+        reservation_price: options[:charge_amount_cents],
         reservation_services_price: reservation.services_with_tax_cents,
         reservation_services: reservation.services.payment_tied_to_reservation.pluck(:name).join(' · ')
       }

--- a/app/policies/reservation_policy.rb
+++ b/app/policies/reservation_policy.rb
@@ -44,6 +44,10 @@ class ReservationPolicy < ApplicationPolicy
     record.user == user
   end
 
+  def secret_services?
+    secret?
+  end
+
   class Scope < Scope
     def resolve
       scope.for_tenant(user).displayable

--- a/app/views/credit_cards/_selection_services.slim
+++ b/app/views/credit_cards/_selection_services.slim
@@ -1,0 +1,15 @@
+- if @credit_cards.blank?
+  .text-center.py-3
+    .py-3
+      p Vous n'avez aucun moyen de paiement
+      p Vous devez en ajouter un avant de pouvoir faire une demande de réservation
+
+    = link_to 'Ajouter une carte', "#", class: 'btn-cookoon btn-cookoon-primary', data: {toggle: "modal", target: "#credit-card-modal"}
+- else
+  = render 'form_services'
+  /.text-center
+  /  div style="font-size:12px; margin-top: 15px"
+  /    p Votre carte bleue ne sera débitée que si l'Hôte accepte votre demande de location.
+  /    p Attention : nous procédons tout de même à une demande d'autorisation de paiement sur votre compte.
+
+= render 'credit_cards/modal'

--- a/app/views/payments/_form_services.html.erb
+++ b/app/views/payments/_form_services.html.erb
@@ -1,0 +1,50 @@
+<div data-controller="stripe-payments"
+     data-stripe-payments-publishable-key="<%= ENV['STRIPE_PUBLISHABLE_KEY'] %>"
+     data-stripe-payments-url="<%= @url_intent_secret_services %>">
+
+  <%= simple_form_for :payment, url: reservation_payments_path(@reservation), html: { data: { target: 'stripe-payments.paymentForm' } }, authenticity_token: true, remote: true do |f| %>
+
+    <b>Vos moyens de paiement</b>
+
+    <div class="credit-card-select payment-block">
+      <i class="co co-cb"></i>
+      <%= f.input :source,
+                  input_html: {
+                    data: {
+                      target: 'stripe-payments.paymentSelection'
+                    }
+                  },
+                  collection: @credit_cards,
+                  selected: @payment_method_to_display_first.id,
+                  label: false,
+                  label_method: ->(card){ credit_card_label_for card },
+                  value_method: ->(card){ card.id }
+      %>
+    </div>
+
+    <!-- We'll put the error messages in this element -->
+    <div class="text-danger" data-target='stripe-payments.paymentError' role="alert"></div>
+
+    <div class="text-center mb-5 text-uppercase">
+      <%= link_to 'Ajouter une carte de paiement', "#", class: 'text-secondary', data: {toggle: "modal", target: "#credit-card-modal"} %>
+    </div>
+
+    <%= f.button :button,
+                'PAYER',
+                type: :submit,
+                class: 'btn-cookoon btn-cookoon-primary btn-block',
+                data: {
+                  controller: 'analytics-events',
+                  action: 'click->analytics-events#reservationPaymentSubmit'
+               }
+    %>
+
+    <div class="text-center">
+      <div style="font-size:12px; margin-top: 15px">
+        <p>Votre carte bleue ne sera débitée que si l'Hôte accepte votre demande de location.</p>
+        <p>Attention : nous procédons tout de même à une demande d'autorisation de paiement sur votre compte.</p>
+      </div>
+    </div>
+  <% end %>
+
+</div>

--- a/app/views/payments/new.slim
+++ b/app/views/payments/new.slim
@@ -5,37 +5,71 @@
   .row
     .d-none.d-md-block.col-md-4.col-lg-3.px-md-2
       .px-md-2.px-lg-0
-        = link_to '< Retour au choix', reservation_cookoon_path(@reservation, @reservation.cookoon), class: 'btn-cookoon btn-block btn-cookoon-secondary-gold mb-2 small'
+        - if @reservation.cookoon_selected? || @reservation.services_selected?
+          = link_to '< Retour aux choix', reservation_cookoon_path(@reservation, @reservation.cookoon), class: 'btn-cookoon btn-block btn-cookoon-secondary-gold mb-2 small'
         = render 'reservations/search_recap', reservation: @reservation
 
     .col-12.col-md-8.col-lg-9.px-0.px-md-2.pr-lg-0
       .px-0.px-md-2.pb-4
-        = render 'reservations/recap_string', reservation: @reservation
+        .pb-4
+          = render 'reservations/recap_string', reservation: @reservation
 
-        .mb-4
+        div.mb-3
+          p.mb-3.font-weight-bold Votre décor et le service
+          p.mb-1
+            |
+              - L'adresse: #{@cookoon.address}
+          p.mb-1
+            |
+              - Le(s) maître(s) d'hôtel
+        div.mb-4
           .d-flex-default
-            b Mise à disposition du lieu
-            b <span>#{humanized_money_with_symbol @reservation.cookoon_price}</span>
-          .ml-3 = @cookoon.address
+            b Montant
+            b #{humanized_money_with_symbol(@reservation.cookoon_price)}TTC
+          .d-flex.justify-content-end
+            i
+              |
+                (soit #{humanized_money_with_symbol(@reservation.cookoon_price)}HT)
 
-          .m-2
-            = render 'reservations/services_prices'
+        hr
 
+        div.mb-3
+          p.mb-3.font-weight-bold Vos souhaits de service
+          - @reservation.services.each do |service|
+            p.mb-1
+              |
+                - &nbsp
+              =service.name
+        div.mb-4
+          .d-flex-default
+            b Montant
+            b #{humanized_money_with_symbol(@reservation.services_with_tax)}TTC
+          .d-flex.justify-content-end
+            i
+              |
+                (soit #{humanized_money_with_symbol(@reservation.services_price)}HT)
+
+        - if @reservation.services_selected? || @reservation.cookoon_selected?
           hr
-
-          .d-flex-default.mb-2
-            b TOTAL
-            - if @reservation.customer?
-              .text-right
-                b.text-primary #{humanized_money_with_symbol @reservation.total_full_price} TTC
-                p soit #{humanized_money_with_symbol(@reservation.total_full_price_per_person)} / personne
-            - else
-              b.text-primary #{humanized_money_with_symbol @reservation.total_price} HT
-
-        - if @reservation.object.aasm_state == "services_selected"
+          hr
+          p.mb-3.font-weight-bold.text-center Régler #{humanized_money_with_symbol(@reservation.cookoon_price)}TTC
           = render 'credit_cards/selection'
+        - if @reservation.accepted?
+          hr
+          hr
+          p.mb-3.font-weight-bold.text-center Régler #{humanized_money_with_symbol(@reservation.services_with_tax)}TTC
+          = render 'credit_cards/selection_services'
 
-          - if @reservation.business?
-            .text-center.mb-4
+        - if @reservation.business?
+          hr
+          hr
+          .text-center.mb-4
+            - if @reservation.services_selected? || @reservation.cookoon_selected?
               p Vous pouvez aussi demander un devis
               = link_to 'Demander un Devis', ask_quotation_reservation_path(@reservation), class: 'btn-cookoon btn-cookoon-primary btn-block', method: :patch
+            - elsif @reservation.quotation_asked?
+              p Votre demande de devis est en cours
+            - elsif @reservation.quotation_proposed?
+              p Nous sommes en attente de votre validation du devis
+            - elsif @reservation.quotation_accepted?
+              p Vous avez validé le devis

--- a/app/views/payments/secret.json.erb
+++ b/app/views/payments/secret.json.erb
@@ -1,1 +1,2 @@
-<%= @intent_secret_json.html_safe %>
+<%#= @intent_secret_json.html_safe %>
+<%= @stripe_intent_secret_json.html_safe %>

--- a/app/views/payments/secret_services.json.erb
+++ b/app/views/payments/secret_services.json.erb
@@ -1,0 +1,2 @@
+<%#= @intent_secret_services_json.html_safe %>
+<%= @stripe_intent_secret_json.html_safe %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,9 +50,11 @@ Rails.application.routes.draw do
       end
     end
     resources :chefs, only: :index
+
     resources :payments, only: %i[new create] do
       collection do
         get 'secret', to: 'payments#secret'
+        get 'secret_services', to: 'payments#secret_services'
       end
     end
     patch 'menus/:id', to: 'reservations#select_menu', as: :select_menu

--- a/db/migrate/20200522200906_add_stripe_services_id_to_reservations.rb
+++ b/db/migrate/20200522200906_add_stripe_services_id_to_reservations.rb
@@ -1,0 +1,5 @@
+class AddStripeServicesIdToReservations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :reservations, :stripe_services_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_04_081116) do
+ActiveRecord::Schema.define(version: 2020_05_22_200906) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -159,6 +159,7 @@ ActiveRecord::Schema.define(version: 2019_09_04_081116) do
     t.integer "services_with_tax_cents", default: 0, null: false
     t.integer "total_tax_cents", default: 0, null: false
     t.integer "total_with_tax_cents", default: 0, null: false
+    t.string "stripe_services_id"
     t.index ["cookoon_id"], name: "index_reservations_on_cookoon_id"
     t.index ["menu_id"], name: "index_reservations_on_menu_id"
     t.index ["user_id"], name: "index_reservations_on_user_id"


### PR DESCRIPTION
- add stripe_services_id field to reservation
- add route for secret_services to get the payment intent client secret from stripe for services
- add method secret_services to payment controller + update reservation policy
- update methods in Reservation model / payment model / stripe_chargeable model to be able to use them for stripe_charge_id & stripe_services_id
- add statuses + events in reservation state machine to allow double payment + quotations workflow
- update new payment view to allow payment in two times 
- add partial form_services in payment views to get the right form when paying services
- add partial selection_services in credit_cards views to get the right credit card form when paying services