### PR TITLE
allow preview mailer in staging

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -78,8 +78,11 @@ Rails.application.configure do
   config.roadie.url_options = { host: 'cookoon-staging.herokuapp.com', scheme: 'https' }
   config.action_mailer.asset_host = nil
 
-  config.action_mailer.show_previews = true
-  config.action_mailer.preview_path = 'spec/mailers/previews'
+  # config mailer previews
+  if ENV['ENABLE_MAILER_PREVIEWS'].present?
+    config.action_mailer.show_previews = true
+    config.action_mailer.preview_path ||= defined?(Rails.root) ? "#{Rails.root}/spec/mailers/previews" : nil
+  end
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
- add ENABLE_MAILER_PREVIEWS: true to dashboard.heroku.com/apps/cookoon-staging/settings Config Variables
- update staging.rb to allow preview mailer in staging