### PR TITLE
Reservation services update by admin

### DIFF
--- a/.forestadmin-schema.json
+++ b/.forestadmin-schema.json
@@ -2937,7 +2937,7 @@
       "widget": null,
       "validations": []
     }, {
-      "field": "services_payment_status",
+      "field": "services_status",
       "type": "String",
       "default_value": "initial",
       "enums": null,
@@ -3170,7 +3170,8 @@
       "default_value": "0",
       "enums": [
         "initial",
-        "quote",
+        "validated",
+        "payment_required",
         "captured",
         "paid"
       ],

--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -3,7 +3,8 @@ module Admin
     # not necessary because it is specified directly in routes
     # before_action :require_admin
     before_action :find_reservation, only: %i[show]
-    before_action :find_reservation_with_renservation_id, only: %i[ask_menu_payment validate_menu]
+    before_action :find_reservation_with_reservation_id, only: %i[validate_menu ask_menu_payment validate_services ask_services_payment]
+
     def index
       @reservations = policy_scope([:admin, Reservation]).includes(:cookoon, :user, menu: [:chef], cookoon: [:user]).order(id: :desc)
     end
@@ -32,6 +33,27 @@ module Admin
       end
     end
 
+    def validate_services
+      if @reservation.update(services_status: "validated")
+        flash.notice = "Les services ont bien été validés"
+        redirect_to admin_reservation_path(@reservation)
+      else
+        flash.alert = "Il y a eu un problème"
+        render :show
+      end
+    end
+
+    def ask_services_payment
+      if @reservation.update(services_status: "payment_required")
+        flash.notice = "Le paiement des services va bien être demandé"
+        # TO DO send email to user to require payment
+        redirect_to admin_reservation_path(@reservation)
+      else
+        flash.alert = "Il y a eu un problème"
+        render :show
+      end
+    end
+
     private
 
     def find_reservation
@@ -39,7 +61,7 @@ module Admin
       authorize @reservation, policy_class: Admin::ReservationPolicy
     end
 
-    def find_reservation_with_renservation_id
+    def find_reservation_with_reservation_id
       @reservation = Reservation.find(params[:reservation_id]).decorate
       authorize @reservation, policy_class: Admin::ReservationPolicy
     end

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -1,0 +1,64 @@
+module Admin
+  class ServicesController < ApplicationController
+    # not necessary because it is specified directly in routes
+    # before_action :require_admin
+    before_action :find_reservation, only: %i[new create edit update]
+    before_action :find_service, only: %i[edit update]
+
+    def new
+      @service = Service.new(reservation: @reservation)
+      authorize @service, policy_class: Admin::ServicePolicy
+    end
+
+    def create
+      @service = Service.new(reservation: @reservation)
+      authorize @service, policy_class: Admin::ServicePolicy
+      @service.assign_attributes(service_params_category)
+      if @service.save
+        redirect_to edit_admin_reservation_service_path(@reservation, @service)
+      else
+        flash[:alert] = "Il y a eu un problème"
+        render :new
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      if @service.update(service_params)
+        @reservation.assign_prices
+        if @reservation.save
+          flash[:notice] = "Les modifications ont bien été enregistrées"
+          redirect_to admin_reservation_path(@reservation)
+        else
+          flash[:alert] = "Il y a eu un problème"
+          render :edit
+        end
+      else
+        flash[:alert] = "Il y a eu un problème"
+        render :edit
+      end
+    end
+
+    private
+
+    def find_reservation
+      @reservation = Reservation.find(params[:reservation_id]).decorate
+    end
+
+    def find_service
+      @service = Service.find(params[:id])
+      authorize @service, policy_class: Admin::ServicePolicy
+    end
+
+    def service_params
+      params.require(:service).permit(:name, :margin, :quantity_base, :base_price, :quantity, :unit_price)
+    end
+
+    def service_params_category
+      params.require(:service).permit(:category)
+    end
+
+  end
+end

--- a/app/decorators/reservation_decorator.rb
+++ b/app/decorators/reservation_decorator.rb
@@ -128,6 +128,11 @@ class ReservationDecorator < Draper::Decorator
     ]
   end
 
+  def services_collection_available_for_view
+    services_affected = builtin_services.map {|element| element.to_sym}
+    services_collection_for_view.delete_if {|element| services_affected.include?(element[1]) unless element[1] == "wine".to_sym }
+  end
+
   def type_names
     {
       breakfast: 'Petit déjeuner',

--- a/app/models/concerns/reservation_state_machine.rb
+++ b/app/models/concerns/reservation_state_machine.rb
@@ -12,7 +12,7 @@ module ReservationStateMachine
       state :charged
       state :accepted
       state :menu_payment_captured
-      state :services_paid
+      state :services_payment_captured
       state :quotation_asked
       state :quotation_proposed
       state :quotation_accepted
@@ -111,7 +111,7 @@ module ReservationStateMachine
   end
 
   def set_prices
-    # assign_prices
-    assign_prices_for_cookoon_butler_menu
+    assign_prices
+    # assign_prices_for_cookoon_butler_menu
   end
 end

--- a/app/models/reservation/payment.rb
+++ b/app/models/reservation/payment.rb
@@ -12,8 +12,10 @@ class Reservation
     end
 
     def capture_menu_payment
-      reservation.capture_menu_payment! if errors.empty?
-      reservation.update(menu_status: "captured")
+      if errors.empty?
+        reservation.capture_menu_payment!
+        reservation.update(menu_status: "captured")
+      end
     end
 
     private

--- a/app/models/reservation/price_computer.rb
+++ b/app/models/reservation/price_computer.rb
@@ -90,7 +90,8 @@ class Reservation
 
     def compute_services_price
       # return 0 unless services.present?
-      Money.new(services.where.not(status: "initial").pluck(:price_cents).sum)
+      # Money.new(services.where.not(status: "initial").pluck(:price_cents).sum)
+      Money.new(services.pluck(:price_cents).sum)
     end
 
     def compute_total_price

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -9,10 +9,14 @@ class Service < ApplicationRecord
   monetize :price_cents
   monetize :base_price_cents
 
-  enum status: %i[initial quote captured paid]
+  # enum status: %i[initial quote captured paid]
+  enum status: %i[initial validated payment_required captured paid]
   enum category: %i[special sommelier parking corporate catering breakfast flowers wine]
 
+  default_scope -> { order(id: :asc) }
+
   before_create :set_name_and_default_prices, :compute_price
+  before_update :compute_price
 
   # validates :category, presence: true
   validates :category, uniqueness: { scope: :reservation }, unless: :wine?
@@ -26,7 +30,8 @@ class Service < ApplicationRecord
   def set_name_and_default_prices
     case category
     when 'special'
-      self.assign_attributes(
+      # self.assign_attributes(
+        assign_attributes(
         name: 'Personnalisé',
         quantity_base: 0,
         base_price: 0,
@@ -35,7 +40,8 @@ class Service < ApplicationRecord
         margin: 0.25
       )
     when 'sommelier'
-      self.assign_attributes(
+      # self.assign_attributes(
+        assign_attributes(
         name: 'Sommelier',
         quantity_base: sommelier_count,
         base_price: 250,
@@ -44,7 +50,8 @@ class Service < ApplicationRecord
         margin: 0.25,
       )
     when 'parking'
-      self.assign_attributes(
+      # self.assign_attributes(
+        assign_attributes(
         name: 'Voiturier',
         quantity_base: 1,
         base_price: 75,
@@ -53,7 +60,8 @@ class Service < ApplicationRecord
         margin: 0.25,
       )
     when 'corporate'
-      self.assign_attributes(
+      # self.assign_attributes(
+        assign_attributes(
         name: 'Kit professionnel',
         quantity_base: 1,
         base_price: 100,
@@ -62,7 +70,8 @@ class Service < ApplicationRecord
         margin: 0.25,
       )
     when 'catering'
-      self.assign_attributes(
+      # self.assign_attributes(
+        assign_attributes(
         name: 'Plateaux repas',
         quantity_base: 1,
         base_price: 50,
@@ -71,7 +80,8 @@ class Service < ApplicationRecord
         margin: 0.25,
       )
     when 'breakfast'
-      self.assign_attributes(
+      # self.assign_attributes(
+        assign_attributes(
         name: 'Petit déjeuner',
         quantity_base: 1,
         base_price: 50,
@@ -80,7 +90,8 @@ class Service < ApplicationRecord
         margin: 2,
       )
     when 'flowers'
-      self.assign_attributes(
+      # self.assign_attributes(
+        assign_attributes(
         name: 'Composition florale',
         quantity_base: 1,
         base_price: 50,
@@ -89,7 +100,8 @@ class Service < ApplicationRecord
         margin: 2,
       )
     when 'wine'
-      self.assign_attributes(
+      # self.assign_attributes(
+        assign_attributes(
         name: 'Vin',
         quantity_base: 0,
         base_price: 0,
@@ -115,11 +127,13 @@ class Service < ApplicationRecord
   end
 
   def wine?
-    self.category == "wine"
+    # self.category == "wine"
+    category == "wine"
   end
 
   def compute_price
-    self.price = (1 + self.margin) * ((self.quantity_base * self.base_price) + (self.quantity * self.unit_price))
+    # self.price = (1 + self.margin) * ((self.quantity_base * self.base_price) + (self.quantity * self.unit_price))
+    assign_attributes(price: (1 + margin) * ((quantity_base * base_price) + (quantity * unit_price)))
   end
 
 end

--- a/app/policies/admin/reservation_policy.rb
+++ b/app/policies/admin/reservation_policy.rb
@@ -11,6 +11,14 @@ class Admin::ReservationPolicy < ApplicationPolicy
     user.admin == true && record.needs_menu_payment_asking?
   end
 
+  def validate_services?
+    user.admin == true && record.needs_services_validation?
+  end
+
+  def ask_services_payment?
+    user.admin == true && record.needs_services_payment_asking?
+  end
+
   class Scope < Scope
     def resolve
       scope.all

--- a/app/policies/admin/service_policy.rb
+++ b/app/policies/admin/service_policy.rb
@@ -1,0 +1,23 @@
+class Admin::ServicePolicy < ApplicationPolicy
+  def new?
+    user.admin == true && record.reservation.accepts_new_service?
+  end
+
+  def create?
+    new?
+  end
+
+  def edit?
+    user.admin == true && record.reservation.needs_services_validation?
+  end
+
+  def update?
+    edit?
+  end
+
+  # class Scope < Scope
+  #   def resolve
+  #     scope.all
+  #   end
+  # end
+end

--- a/app/views/admin/reservations/index.html.erb
+++ b/app/views/admin/reservations/index.html.erb
@@ -29,6 +29,10 @@
           <li class="nav-item">
             <a href="#accepted" class="nav-link" data-toggle="pill" role="tab">Accepted</a>
           </li>
+
+          <li class="nav-item">
+            <a href="#menu_payment_captured" class="nav-link" data-toggle="pill" role="tab">Menu payment captured</a>
+          </li>
         </ul>
       </div>
 
@@ -39,6 +43,9 @@
           </div>
           <div class="tab-pane fade" id="accepted" role="tabpanel">
             <%= render "list", resas: @reservations.accepted.decorate %>
+          </div>
+          <div class="tab-pane fade" id="menu_payment_captured" role="tabpanel">
+            <%= render "list", resas: @reservations.menu_payment_captured.decorate %>
           </div>
         </div>
       </div>

--- a/app/views/admin/reservations/show.html.erb
+++ b/app/views/admin/reservations/show.html.erb
@@ -54,7 +54,7 @@
               <p>Frais de service: <%= service.quantity_base %> x <%= service.base_price %></p>
               <p>Marge: <%= service.margin %></p>
               <p>Total HT avec marge: <%= service.price %></p>
-              <% if policy([:admin, service]).edit? %>
+              <% if @reservation.accepts_new_service? %>
                 <%= link_to 'Modifier', edit_admin_reservation_service_path(@reservation, service), :class => "btn-cookoon btn-cookoon-primary mb-4" %>
               <% end %>
             </div>

--- a/app/views/admin/reservations/show.html.erb
+++ b/app/views/admin/reservations/show.html.erb
@@ -48,8 +48,25 @@
         <h3 class="mt-3">Services</h3>
         <% if @reservation.services.present? %>
           <% @reservation.services.each do |service| %>
-            <p><%= service.category %></p>
-            <p><%= service.unit_price %></p>
+            <div class="mb-5">
+              <p><%= service.name %></p>
+              <p>Tarif: <%= service.quantity %> x <%= service.unit_price %></p>
+              <p>Frais de service: <%= service.quantity_base %> x <%= service.base_price %></p>
+              <p>Marge: <%= service.margin %></p>
+              <p>Total HT avec marge: <%= service.price %></p>
+              <% if policy([:admin, service]).edit? %>
+                <%= link_to 'Modifier', edit_admin_reservation_service_path(@reservation, service), :class => "btn-cookoon btn-cookoon-primary mb-4" %>
+              <% end %>
+            </div>
+          <% end %>
+          <% if @reservation.accepts_new_service? %>
+            <%= link_to 'Ajouter un service', new_admin_reservation_service_path(@reservation), :class => "btn-cookoon btn-cookoon-primary mb-4" %>
+          <% end %>
+          <% if @reservation.needs_services_validation? %>
+            <%= link_to 'Valider les services', admin_reservation_validate_services_path(@reservation), :class => "btn-cookoon btn-cookoon-primary mb-4", method: :patch %>
+          <% end %>
+          <% if @reservation.needs_services_payment_asking? %>
+            <%= link_to 'Demander le paiement des services', admin_reservation_ask_services_payment_path(@reservation), :class => "btn-cookoon btn-cookoon-primary mb-4", method: :patch %>
           <% end %>
         <% else %>
           <p>Aucun service n'a été sélectionné</p>

--- a/app/views/admin/services/edit.slim
+++ b/app/views/admin/services/edit.slim
@@ -1,0 +1,28 @@
+.container.px-0
+  .row.mx-0
+    .d-none.d-md-block.col-md-4.col-lg-3.px-0.pr-3
+
+    .col-12.col-md-8.col-lg-9.px-0
+      .breadcrumbs
+        h1.text-center.first-title = @service.name
+      hr.breadcrumbs-hr
+
+.container.d-flex.justify-content-center.px-0.pb-5
+  .row
+    .d-none.d-md-block.col-md-4.col-lg-3.px-0.pr-3
+      = render 'shared/back_button_transparent', button_title: 'Retour à la réservation', path: admin_reservation_path(@reservation)
+
+    .col-12.col-md-8.col-lg-9.px-0
+      = simple_form_for [:admin, @reservation, @service] do |f|
+        .form-inputs
+          - if @service.category == "wine"
+            = f.input :name
+          = f.input :margin
+          = f.input :quantity_base
+          = f.input :base_price
+          = f.input :quantity
+          = f.input :unit_price
+
+        .form-actions.mb-4
+          .text-center
+            = f.submit class: 'btn-cookoon btn-cookoon-primary px-5'

--- a/app/views/admin/services/new.slim
+++ b/app/views/admin/services/new.slim
@@ -1,0 +1,22 @@
+.container.px-0
+  .row.mx-0
+    .d-none.d-md-block.col-md-4.col-lg-3.px-0.pr-3
+
+    .col-12.col-md-8.col-lg-9.px-0
+      .breadcrumbs
+        h1.text-center.first-title Nouveau service
+      hr.breadcrumbs-hr
+
+.container.d-flex.justify-content-center.px-0.pb-5
+  .row
+    .d-none.d-md-block.col-md-4.col-lg-3.px-0.pr-3
+      = render 'shared/back_button_transparent', button_title: 'Retour à la réservation', path: admin_reservation_path(@reservation)
+
+    .col-12.col-md-8.col-lg-9.px-0
+      = simple_form_for [:admin, @reservation, @service] do |f|
+        .form-inputs
+          = f.input :category, as: :select, collection: @reservation.services_collection_available_for_view, prompt: true
+
+        .form-actions.mb-4
+          .text-center
+            = f.submit class: 'btn-cookoon btn-cookoon-primary px-5'

--- a/app/views/menus/_card.slim
+++ b/app/views/menus/_card.slim
@@ -29,6 +29,6 @@
   - if policy(@reservation).select_menu?
     = link_to 'Choisir ce menu', reservation_menu_select_menu_path(@reservation, menu), class: 'btn-cookoon btn-block btn-cookoon-primary', method: :patch
   - if policy([:admin, @reservation]).validate_menu?
-    = link_to 'Valider', admin_reservation_validate_menu_path(@reservation), class: 'btn-cookoon btn-block btn-cookoon-primary', method: :patch
+    = link_to 'Valider ce menu', admin_reservation_validate_menu_path(@reservation), class: 'btn-cookoon btn-block btn-cookoon-primary', method: :patch
   - if policy([:admin, @reservation]).ask_menu_payment?
-    = link_to 'Demander le paiement', admin_reservation_ask_menu_payment_path(@reservation), class: 'btn-cookoon btn-block btn-cookoon-primary', method: :patch
+    = link_to 'Demander le paiement du menu', admin_reservation_ask_menu_payment_path(@reservation), class: 'btn-cookoon btn-block btn-cookoon-primary', method: :patch

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,8 +109,11 @@ Rails.application.routes.draw do
         patch 'menus/:id/archive_menu', to: 'menus#archive_menu', as: :archive_menu
       end
       resources :reservations, only: %i[index show] do
-        patch :ask_menu_payment
         patch :validate_menu
+        patch :ask_menu_payment
+        resources :services, only: %i[new create edit update]
+        patch :validate_services
+        patch :ask_services_payment
       end
       # patch 'reservations/:id', to: 'reservations#require_payment_for_menus', as: :require_payment_for_menus
       # patch 'reservations/:id', to: 'reservations#validate_menus', as: :validate_menus

--- a/db/migrate/20200824121106_rename_services_payment_status_column_name_to_reservations.rb
+++ b/db/migrate/20200824121106_rename_services_payment_status_column_name_to_reservations.rb
@@ -1,0 +1,5 @@
+class RenameServicesPaymentStatusColumnNameToReservations < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :reservations, :services_payment_status, :services_status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_23_100809) do
+ActiveRecord::Schema.define(version: 2020_08_24_121106) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -202,7 +202,7 @@ ActiveRecord::Schema.define(version: 2020_08_23_100809) do
     t.integer "menu_with_tax_cents", default: 0, null: false
     t.string "cookoon_butler_payment_status", default: "initial", null: false
     t.string "menu_status", default: "initial", null: false
-    t.string "services_payment_status", default: "initial", null: false
+    t.string "services_status", default: "initial", null: false
     t.integer "butler_price_cents", default: 0, null: false
     t.integer "butler_tax_cents", default: 0, null: false
     t.integer "butler_with_tax_cents", default: 0, null: false

--- a/spec/concerns/reservation/price_computer_spec.rb
+++ b/spec/concerns/reservation/price_computer_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Reservation::PriceComputer do
     it 'computes services_price' do
       # puts reservation.services.pluck(:price_cents) unless reservation.services.nil?
       # puts prices[:services][:services_price]
-      expect(prices[:services][:services_price]).to eq(Money.new 0, 'EUR')
+      expect(prices[:services][:services_price]).to eq(Money.new 78500, 'EUR')
     end
 
     it 'computes total_price' do
@@ -65,7 +65,7 @@ RSpec.describe Reservation::PriceComputer do
       # puts prices[:menu][:menu_price]
       # puts prices[:services][:services_price]
       # puts prices[:total][:total_price]
-      expect(prices[:total][:total_price]).to eq(Money.new 58500, 'EUR')
+      expect(prices[:total][:total_price]).to eq(Money.new 137000, 'EUR')
     end
 
     it 'computes butler_tax' do
@@ -82,7 +82,7 @@ RSpec.describe Reservation::PriceComputer do
     end
 
     it 'computes services_tax' do
-      expect(prices[:services][:services_tax]).to eq(Money.new 0, 'EUR')
+      expect(prices[:services][:services_tax]).to eq(Money.new 15700, 'EUR')
     end
 
     it 'computes total_tax' do
@@ -90,7 +90,7 @@ RSpec.describe Reservation::PriceComputer do
       # puts prices[:menu][:menu_tax]
       # puts prices[:services][:services_tax]
       # puts prices[:total][:total_tax]
-      expect(prices[:total][:total_tax]).to eq(Money.new 6300, 'EUR')
+      expect(prices[:total][:total_tax]).to eq(Money.new 22000, 'EUR')
     end
 
     it 'computes butler_with_tax' do
@@ -111,12 +111,12 @@ RSpec.describe Reservation::PriceComputer do
 
     it 'computes services_with_tax' do
       # puts prices[:services]
-      expect(prices[:services][:services_with_tax]).to eq(Money.new 0, 'EUR')
+      expect(prices[:services][:services_with_tax]).to eq(Money.new 94200, 'EUR')
     end
 
     it 'computes total_with_tax' do
       # puts prices[:total]
-      expect(prices[:total][:total_with_tax]).to eq(Money.new 64800, 'EUR')
+      expect(prices[:total][:total_with_tax]).to eq(Money.new 159000, 'EUR')
     end
   end
 end


### PR DESCRIPTION
- implement reservations actions  for administrator to validate_services and ask_services_payment
=> update routes / admin reservation policy / admin reservations controller / admin reservations view
=> add model methods to reservation to well define policy

- implement services actions for administrator to add a new service and modify service (actions new create edit update)
=> add routes
=> add admin service policy / admin services controller / admin reservations views
=> add model methods to service to well define policy

- change affectation of prices on reservation
=> simplify the process : only one price computing function taking account of everything including services
=> update rspec tests on price computing

- rename column services_payment_status in services _status (for reservation)