### PR TITLE
Design modifications

### DIFF
--- a/app/decorators/reservation_decorator.rb
+++ b/app/decorators/reservation_decorator.rb
@@ -145,14 +145,14 @@ class ReservationDecorator < Draper::Decorator
 
   def type_names
     {
-      breakfast: 'Petit déjeuner',
-      lunch: 'Déjeuner',
-      diner: 'Dîner',
-      cocktail: 'Cocktail',
-      morning: 'Matinée',
-      day: 'Journée',
-      afternoon: 'Après-midi',
-      brunch: 'Brunch'
+      breakfast: 'petit-déjeuner',
+      lunch: 'déjeuner',
+      diner: 'dîner',
+      cocktail: 'cocktail',
+      morning: 'matinée',
+      day: 'journée',
+      afternoon: 'après-midi',
+      brunch: 'brunch'
     }
   end
 

--- a/app/frontend/controllers/mapbox_controller.js
+++ b/app/frontend/controllers/mapbox_controller.js
@@ -34,6 +34,8 @@ export default class extends Controller {
     return new mapboxgl.Map({
       container: 'map_container',
       style: 'mapbox://styles/mapbox/streets-v11',
+      center: [2.3488, 48.8534], // starting position [lng, lat]
+      zoom: 10 // starting zoom
     });
   }
 

--- a/app/frontend/style/components/_chef_four_elements_block.scss
+++ b/app/frontend/style/components/_chef_four_elements_block.scss
@@ -64,6 +64,10 @@
   }
 
   >.fourth_element {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
     @media (min-width: 768px) {
       grid-column: 2;
       grid-row: 4 / span 2;

--- a/app/frontend/style/components/_citation.scss
+++ b/app/frontend/style/components/_citation.scss
@@ -20,7 +20,7 @@
     background-image: url(../../assets/images/quote-end-gold.png);
     // content: url('https://api.iconify.design/icomoon-free:quotes-right.svg?height=16');
     vertical-align: top;
-    margin-left: 0.25rem;
+    margin-left: 0.5rem;
     margin-top: -0.5rem;
   }
 }

--- a/app/frontend/style/components/_common.scss
+++ b/app/frontend/style/components/_common.scss
@@ -1,0 +1,7 @@
+.first-letter-bigger::first-letter {
+  font-size: 3.5rem;
+  float: left;
+  margin: -1rem 0.8rem -1.5rem 0; /* haut | droit | bas | gauche */
+  font-weight: 900;
+  text-transform: capitalize;
+}

--- a/app/frontend/style/components/_cookoon_description_block.scss
+++ b/app/frontend/style/components/_cookoon_description_block.scss
@@ -44,6 +44,11 @@
   }
 
   >.third_element {
+    display: flex;
+    justify-content: flex-end;
+    flex-direction: column;
+    text-align: center;
+
     @media (min-width: 992px) {
       grid-column: 3;
       grid-row: 1;

--- a/app/frontend/style/components/_index.scss
+++ b/app/frontend/style/components/_index.scss
@@ -31,3 +31,4 @@
 @import 'cookoon_description_block.scss';
 @import 'chef_four_elements_block';
 @import 'menu_card';
+@import 'common';

--- a/app/frontend/style/components/_search_recap.scss
+++ b/app/frontend/style/components/_search_recap.scss
@@ -88,7 +88,7 @@
 .search-details {
   > p {
     margin-bottom: 0;
-    color: $primary;
+    // color: $primary;
     text-transform: uppercase;
   }
   > img {

--- a/app/frontend/style/override/simple_form/_custom.scss
+++ b/app/frontend/style/override/simple_form/_custom.scss
@@ -70,3 +70,12 @@ label.collection_check_boxes {
 .form-check-label {
   margin-left: 0.5rem;
 }
+
+.form-group.date.user_born_on > div.d-flex.flex-row.justify-content-between.align-items-center {
+  justify-content: flex-start !important;
+  > select {
+    width: fit-content;
+    margin-left: 0 !important;
+    margin-right: 0.75rem !important;
+  }
+}

--- a/app/views/admin/chefs/show.slim
+++ b/app/views/admin/chefs/show.slim
@@ -24,7 +24,7 @@
         hr.primary.mt-n1.mb-1
         p.text-primary.text-center.font-italic.pb-2 signés #{@chef.name}
 
-        = render 'menus/list', menus: @chef.menus.active.includes(:dishes), chef: @chef
+        = render 'admin/menus/list', menus: @chef.menus.active.includes(:dishes), chef: @chef
 
       //.mt-2
         = render 'chefs/perks', chef_perks: @chef.chef_perks

--- a/app/views/admin/menus/_card.slim
+++ b/app/views/admin/menus/_card.slim
@@ -10,7 +10,7 @@
     .text-primary.my-2
       '*****
   .menu-card-price.mb-4
-    .text-primary Prix:
+    .text-primary Prix HT sans marge:
     span #{menu.unit_price} €
     .text-primary.pt-3 Statut:
     span #{menu.status}

--- a/app/views/admin/menus/_list.slim
+++ b/app/views/admin/menus/_list.slim
@@ -1,3 +1,3 @@
 .menu-cards
-  - menus.each do |menu|
+  - menus.includes(:dishes).each do |menu|
     = render 'admin/menus/card', menu: menu, chef: @chef

--- a/app/views/admin/reservations/index.html.erb
+++ b/app/views/admin/reservations/index.html.erb
@@ -33,6 +33,10 @@
           <li class="nav-item">
             <a href="#menu_payment_captured" class="nav-link" data-toggle="pill" role="tab">Menu payment captured</a>
           </li>
+
+          <li class="nav-item">
+            <a href="#services_payment_captured" class="nav-link" data-toggle="pill" role="tab">Services payment captured</a>
+          </li>
         </ul>
       </div>
 
@@ -46,6 +50,9 @@
           </div>
           <div class="tab-pane fade" id="menu_payment_captured" role="tabpanel">
             <%= render "list", resas: @reservations.menu_payment_captured.decorate %>
+          </div>
+          <div class="tab-pane fade" id="services_payment_captured" role="tabpanel">
+            <%= render "list", resas: @reservations.services_payment_captured.decorate %>
           </div>
         </div>
       </div>

--- a/app/views/chefs/_details_part.slim
+++ b/app/views/chefs/_details_part.slim
@@ -8,8 +8,11 @@
 
 .chef_four_elements_block.pb-5
   .first_element
-    = chef.description
+    .first-letter-bigger = chef.description
     - if @chef.references.present?
+      .text-center.my-2
+        - 3.times do
+          = image_tag("cookoon-losange.png", size: '24')
       .chef_references = simple_format(@chef.references)
   .second_element style="background-image: url(#{cl_image_path(chef.photos.first.path)})"
   .third_element style="background-image: url(#{cl_image_path(chef.photos.second.path)})"

--- a/app/views/chefs/_details_part.slim
+++ b/app/views/chefs/_details_part.slim
@@ -13,5 +13,5 @@
       .chef_references = simple_format(@chef.references)
   .second_element style="background-image: url(#{cl_image_path(chef.photos.first.path)})"
   .third_element style="background-image: url(#{cl_image_path(chef.photos.second.path)})"
-  .fourth_element.d-flex.align-items-center
+  .fourth_element
     .citation.mb-2.py-5 = chef.citation

--- a/app/views/chefs/_details_part.slim
+++ b/app/views/chefs/_details_part.slim
@@ -1,7 +1,7 @@
 .mb-3
   p.text-primary.mb-1 Vous rencontrez...
   .d-flex.justify-content-between
-    h2.font-italic.mb-0 style = "font-family: 'Avenir'" = chef.name
+    h2.mb-0 style = "font-family: 'Avenir'" = chef.name
     = render 'chefs/perks', chef_perks: chef.chef_perks
   div style="height: 250px; background-image: url(#{cl_image_path(chef.main_photo.path)}); background-size: cover; background-position: center"
 

--- a/app/views/cookoons/_details_part.slim
+++ b/app/views/cookoons/_details_part.slim
@@ -13,7 +13,7 @@
 
   .second_element style="background-image:url(#{cl_image_path(cookoon.long_photo.path)})"
 
-  .third_element.d-flex.flex-column.justify-content-end.pt-5
+  .third_element.pt-5
     .citation.mb-2
       span = cookoon.citation
     img src=cl_image_path(@sample_photos.first.path) style="height:250px; width: 100%; object-fit: cover"

--- a/app/views/cookoons/_details_part.slim
+++ b/app/views/cookoons/_details_part.slim
@@ -2,7 +2,7 @@
   .first_element
     div.mb-3
       p.text-primary.mb-1 Vous visitez...
-      h2.font-italic.mb-0 style = "font-family: 'Avenir'" = cookoon.name
+      h2.mb-0 style = "font-family: 'Avenir'" = cookoon.name
     div.mb-3
       .d-flex.justify-content-between.mb-1.text-right
         p.mb-0 = cookoon.category

--- a/app/views/cookoons/_details_part.slim
+++ b/app/views/cookoons/_details_part.slim
@@ -2,7 +2,7 @@
   .first_element
     div.mb-3
       p.text-primary.mb-1 Vous visitez...
-      h2.mb-0 style = "font-family: 'Avenir'" = cookoon.name
+      h2.font-italic.mb-0 style = "font-family: 'Avenir'" = cookoon.name
     div.mb-3
       .d-flex.justify-content-between.mb-1.text-right
         p.mb-0 = cookoon.category

--- a/app/views/cookoons/_details_part.slim
+++ b/app/views/cookoons/_details_part.slim
@@ -9,7 +9,7 @@
         p.mb-0.text-primary <i class="fas fa-map-marker-alt"></i> #{cookoon.address}
       img src=cl_image_path(cookoon.main_photo.path) style="height:250px; width: 100%; object-fit: cover"
       .mt-2 = render 'cookoons/perks_in_show', perks: cookoon.perks.includes(:perk_specification)
-    p.mb-0 = cookoon.description
+    p.mb-0.first-letter-bigger = cookoon.description
 
   .second_element style="background-image:url(#{cl_image_path(cookoon.long_photo.path)})"
 

--- a/app/views/devise/sessions/new.slim
+++ b/app/views/devise/sessions/new.slim
@@ -3,9 +3,10 @@
     .text-center
       i.co.icon-cookoon-logo.fa-4x.text-primary
       h1 style="font-family: 'Avenir', serif;" COOKOON
-      p NOUS SOMMES <span class='text-primary'>COOKOON</span>
+      //p NOUS SOMMES <span class='text-primary'>COOKOON</span>
+      p.mb-5 GASTRONOMIE PRIVEE
 
-      h3 Bienvenue à vous !
+      //h3 Bienvenue à vous !
       p#devise-failure-invalid.text-danger
 
     .d-flex.justify-content-around

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -117,7 +117,7 @@
               <tr>
                 <td align="center" class="header">
                   <%#= image_tag('mailer-header.jpg', alt: 'COOKOON') %>
-                  <%= link_to "#{image_tag('cookoon-logo-favicon.png', alt: 'COOKOON', style:'width: 75px; padding: 2rem 0')}".html_safe, 'https://cookoon.club/', target: :_blank %>
+                  <%= link_to "#{image_tag('cookoon-logo-favicon.png', alt: 'COOKOON', style:'width: 50px; padding: 2rem 0')}".html_safe, 'https://cookoon.club/', target: :_blank %>
                 </td>
               </tr>
 

--- a/app/views/pages/home.slim
+++ b/app/views/pages/home.slim
@@ -4,7 +4,7 @@
 .home-banner style= "z-index: 0; position: relative; display: flex; justify-content: center; align-items: center;"
   = carousel_for(['cookoon-table-1.jpg', 'cookoon-chefs.jpg'])
 
-  .banner-title-area
+  //.banner-title-area
     h1.text-center Vivez une expérience</br>singulière, élégante et discrète
 
 .container

--- a/app/views/reservations/_search_recap.slim
+++ b/app/views/reservations/_search_recap.slim
@@ -14,11 +14,12 @@
     p.search-recap-box-data
       i.co.icon-cookoon-logo.fa-2x.text-primary
 .search-details
+  - if reservation.cookoon.present? || reservation.menu.present?
+    p.small.mt-5.text-primary.font-weight-bold Votre réservation
+    hr.w-50.ml-0
   - if reservation.cookoon.present?
-    p.small.mt-4 Votre décor
-    p.small = reservation.cookoon.name
+    p.small.mt-4 = reservation.cookoon.name
     = cl_image_tag(reservation.cookoon.main_photo.path)
   - if reservation.menu.present?
-    p.small.mt-4 Votre chef
-    p.small = reservation.menu.chef.name
+    p.small.mt-4 = reservation.menu.chef.name
     = cl_image_tag(reservation.menu.chef.main_photo.path)


### PR DESCRIPTION
Design:
- change text in connexion screen (Nous sommes Cookoon / Bienvenue à vous => Gastronomie privée)
- title for cookoons and chefs font not italic
- reducing cookoon logo size in mailer layout
- mapbox container centered on paris (instead of nigeria)
- center citation for chefs and cookoons
- typename downcased instead of uppcase
- add title 'Votre réservation' between 4 boxes search récap and cookoon selected
- title in banner removed
- custom user_born_on input to display date on left and not on all width
- for cookoon description / chef description, put first letter bigger than rest of description

Corrections: 
- admin/dashboard/reservations : add services payment captured tab
- admin/chefs/show : correct rendering (render 'menus/list' => render 'admin/menus/list'