### PR TITLE
Display seated or standing meal depending on reservation seated or standing

### DIFF
--- a/app/controllers/admin/menus_controller.rb
+++ b/app/controllers/admin/menus_controller.rb
@@ -40,8 +40,8 @@ module Admin
     end
 
     def validate_menu
-      if @chef.reached_max_active_menus_count?
-        @menu.errors.messages[:status] = "Un maximum de deux menus actifs par chef est autorisé. Archivez des menus"
+      if ((@menu.standing? && @chef.reached_max_active_menus_count?("standing_meal")) || (@menu.seated? && @chef.reached_max_active_menus_count?("seated_meal")))
+        @menu.errors.messages[:status] = "2 menus actifs max en format debout par chef / 2 menus actifs max en format assis par chef. Archivez des menus"
         redirect_to admin_chef_path(@chef), alert: @menu.errors.messages
         # render 'admin/chefs/show', anchor: "menu-id-#{@menu.id}"
       else

--- a/app/controllers/chefs_controller.rb
+++ b/app/controllers/chefs_controller.rb
@@ -4,15 +4,16 @@ class ChefsController < ApplicationController
   before_action :find_chef, only: %i[show]
 
   def index
-    # filtering_params = {
-    #   accomodates_for: @reservation.people_count,
-    #   available_in: (@reservation.start_at..@reservation.end_at),
-    #   available_for: current_user
-    # }
-
     # TO DO display only chefs that do not have another reservation
-    # policy_scope displays chef that only have active menus thanks to scope.has_active_menus in chef policy
-    @chefs = policy_scope(Chef).includes(:main_photo_files, :chef_perks, chef_perks: :chef_perk_specification)
+    # # policy_scope displays chef that only have active menus thanks to scope.has_active_menus in chef policy
+    # @chefs = policy_scope(Chef).includes(:main_photo_files, :chef_perks, chef_perks: :chef_perk_specification)
+    if @reservation.seated?
+      @chefs = policy_scope(Chef).has_active_seated_menus.includes(:main_photo_files, :chef_perks, chef_perks: :chef_perk_specification)
+    elsif @reservation.standing?
+      @chefs = policy_scope(Chef).has_active_standing_menus.includes(:main_photo_files, :chef_perks, chef_perks: :chef_perk_specification)
+    else
+      @chefs = policy_scope(Chef).none
+    end
   end
 
   def show

--- a/app/models/chef.rb
+++ b/app/models/chef.rb
@@ -34,8 +34,8 @@ class Chef < ApplicationRecord
     end
   end
 
-  def reached_max_active_menus_count?
-    menus.where(status: "active").count >= Menu::MAX_PER_CHEF
+  def reached_max_active_menus_count?(meal_type)
+    menus.active.where("meal_type = ?", meal_type).count >= Menu::MAX_PER_CHEF
   end
 
   def computed_min_price_with_margin

--- a/app/models/chef.rb
+++ b/app/models/chef.rb
@@ -22,7 +22,9 @@ class Chef < ApplicationRecord
   monetize :base_price_cents
   monetize :min_price_cents
 
-  scope :has_active_menus, -> { where(id: Menu.where(status: "active").pluck(:chef_id)) }
+  # scope :has_active_menus, -> { where(id: Menu.where(status: "active").pluck(:chef_id)) }
+  scope :has_active_seated_menus, -> { where(id: Menu.active.seated.pluck(:chef_id)) }
+  scope :has_active_standing_menus, -> { where(id: Menu.active.standing.pluck(:chef_id)) }
 
   def base_price_or_min_price_positive
     if base_price.positive? && min_price.positive?

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -21,6 +21,8 @@ class Menu < ApplicationRecord
   scope :active, -> { where("status = 'active'") }
   scope :initial, -> { where("status = 'initial'") }
   scope :archived, -> { where("status = 'archived'") }
+  scope :seated, -> { where("meal_type = 'seated_meal'") }
+  scope :standing, -> { where("meal_type = 'standing_meal'") }
 
   def active?
     status == "active"

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -33,6 +33,14 @@ class Menu < ApplicationRecord
     status == "initial"
   end
 
+  def standing?
+    meal_type == "standing_meal"
+  end
+
+  def seated?
+    meal_type == "seated_meal"
+  end
+
   def computed_price_with_margin
     compute_price_with_margin
   end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -15,7 +15,8 @@ class Menu < ApplicationRecord
   validates :status, presence: true, inclusion: { in: Menu::STATUSES }
   validates :meal_type, presence: true, inclusion: { in: Menu::MEAL_TYPES.keys }
 
-  default_scope -> { order(unit_price_cents: :asc) }
+  # default_scope -> { order(unit_price_cents: :asc) }
+  scope :order_by_asc_price, -> { order(unit_price_cents: :asc) }
   scope :active, -> { where("status = 'active'") }
   scope :initial, -> { where("status = 'initial'") }
   scope :archived, -> { where("status = 'archived'") }

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -17,6 +17,7 @@ class Menu < ApplicationRecord
 
   # default_scope -> { order(unit_price_cents: :asc) }
   scope :order_by_asc_price, -> { order(unit_price_cents: :asc) }
+  scope :order_by_meal_type, -> { order(meal_type: :asc) }
   scope :active, -> { where("status = 'active'") }
   scope :initial, -> { where("status = 'initial'") }
   scope :archived, -> { where("status = 'archived'") }

--- a/app/policies/chef_policy.rb
+++ b/app/policies/chef_policy.rb
@@ -1,7 +1,8 @@
 class ChefPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope.has_active_menus
+      # scope.has_active_menus
+      scope.all
     end
   end
 end

--- a/app/views/admin/chefs/show.slim
+++ b/app/views/admin/chefs/show.slim
@@ -24,7 +24,7 @@
         hr.primary.mt-n1.mb-1
         p.text-primary.text-center.font-italic.pb-2 signés #{@chef.name}
 
-        = render 'admin/menus/list', menus: @chef.menus.active.includes(:dishes), chef: @chef
+        = render 'admin/menus/list', menus: @chef.menus.active.order_by_asc_price.includes(:dishes), chef: @chef
 
       //.mt-2
         = render 'chefs/perks', chef_perks: @chef.chef_perks
@@ -60,20 +60,20 @@
 
       h5 Les menus actifs
       - if @chef.menus.active.present?
-        = render 'admin/menus/list', menus: @chef.menus.active
+        = render 'admin/menus/list', menus: @chef.menus.active.order_by_asc_price
 
       - else
         p Il n'y a pas de menu actif pour ce Chef
 
       h5.pt-4 Les menus avec statut "initial"
       - if @chef.menus.initial.present?
-        = render 'admin/menus/list', menus: @chef.menus.initial
+        = render 'admin/menus/list', menus: @chef.menus.initial.order_by_asc_price
       - else
         p Il n'y a pas de menu avec statut "initial" pour ce Chef
 
       h5.pt-4 Les menus archivés
       - if @chef.menus.archived.present?
-        = render 'admin/menus/list', menus: @chef.menus.archived
+        = render 'admin/menus/list', menus: @chef.menus.archived.order_by_asc_price
       - else
         p Il n'y a pas de menu archivé pour ce Chef
 

--- a/app/views/admin/chefs/show.slim
+++ b/app/views/admin/chefs/show.slim
@@ -24,7 +24,7 @@
         hr.primary.mt-n1.mb-1
         p.text-primary.text-center.font-italic.pb-2 signés #{@chef.name}
 
-        = render 'admin/menus/list', menus: @chef.menus.active.order_by_asc_price.includes(:dishes), chef: @chef
+        = render 'admin/menus/list', menus: @chef.menus.active.order_by_meal_type.order_by_asc_price.includes(:dishes), chef: @chef
 
       //.mt-2
         = render 'chefs/perks', chef_perks: @chef.chef_perks
@@ -60,20 +60,20 @@
 
       h5 Les menus actifs
       - if @chef.menus.active.present?
-        = render 'admin/menus/list', menus: @chef.menus.active.order_by_asc_price
+        = render 'admin/menus/list', menus: @chef.menus.active.order_by_meal_type.order_by_asc_price
 
       - else
         p Il n'y a pas de menu actif pour ce Chef
 
       h5.pt-4 Les menus avec statut "initial"
       - if @chef.menus.initial.present?
-        = render 'admin/menus/list', menus: @chef.menus.initial.order_by_asc_price
+        = render 'admin/menus/list', menus: @chef.menus.initial.order_by_meal_type.order_by_asc_price
       - else
         p Il n'y a pas de menu avec statut "initial" pour ce Chef
 
       h5.pt-4 Les menus archivés
       - if @chef.menus.archived.present?
-        = render 'admin/menus/list', menus: @chef.menus.archived.order_by_asc_price
+        = render 'admin/menus/list', menus: @chef.menus.archived.order_by_meal_type.order_by_asc_price
       - else
         p Il n'y a pas de menu archivé pour ce Chef
 

--- a/app/views/chefs/show.slim
+++ b/app/views/chefs/show.slim
@@ -19,4 +19,7 @@
         hr.primary.mt-n1.mb-1
         p.text-primary.text-center.font-italic.pb-2 signés #{@chef.name}
 
-        = render 'menus/list', menus: @chef.menus.active.order_by_asc_price
+      - if @reservation.seated?
+        = render 'menus/list', menus: @chef.menus.active.seated.order_by_asc_price
+      - elsif @reservation.standing?
+        = render 'menus/list', menus: @chef.menus.active.standing.order_by_asc_price

--- a/app/views/chefs/show.slim
+++ b/app/views/chefs/show.slim
@@ -19,4 +19,4 @@
         hr.primary.mt-n1.mb-1
         p.text-primary.text-center.font-italic.pb-2 signés #{@chef.name}
 
-        = render 'menus/list', menus: @chef.menus.active
+        = render 'menus/list', menus: @chef.menus.active.order_by_asc_price

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -171,7 +171,8 @@ chef_attributes = [
     min_price: 500,
     references: "Restaurant : Hélène Darroze",
     main_photo_url: "https://static.lexpress.fr/medias_11664/w_2048,h_1146,c_crop,x_0,y_0/w_1000,h_563,c_fill,g_north/v1509987362/helene-darroze-portrait_5972444.jpg",
-    citation: "Je suis un super Chef"
+    citation: "Je suis un super Chef",
+    gender: "female"
   },
   {
     name: 'Gordon Ramsay',
@@ -183,7 +184,8 @@ chef_attributes = [
     min_price: 500,
     references: "Restaurant : le Gordon\nPublications: Mes meilleures recettes",
     main_photo_url: "https://upload.wikimedia.org/wikipedia/commons/6/6f/Gordon_Ramsay.jpg",
-    citation: "Je suis un super Chef"
+    citation: "Je suis un super Chef",
+    gender: "male"
   }
 ]
 
@@ -195,7 +197,8 @@ menu_attributes = [
   {
     chef: Chef.first,
     status: "active",
-    unit_price_cents: 3500,
+    unit_price_cents: 5000,
+    meal_type: "seated_meal",
     description: <<-DESCRIPTION
       Menu d'hiver
     DESCRIPTION
@@ -203,20 +206,23 @@ menu_attributes = [
   {
     chef: Chef.first,
     status: "active",
-    unit_price_cents: 5000,
-    description: "Menu de printemps"
+    unit_price_cents: 3000,
+    description: "Menu de printemps",
+    meal_type: "seated_meal"
   },
   {
     chef: Chef.last,
     status: "active",
     unit_price_cents: 3500,
-    description: "Menu d'été"
+    description: "Menu d'été",
+    meal_type: "seated_meal"
   },
   {
     chef: Chef.last,
     status: "initial",
     unit_price_cents: 5000,
-    description: "Menu d'automne"
+    description: "Menu d'automne",
+    meal_type: "standing_meal"
   }
 ]
 


### PR DESCRIPTION
- seed : add gender to chefs + meal_type to menus
- add scope to Chef model (has_active_menus)  / update reached_max_active_menus_count?(meal_type) class method to take account of seated or standing menus 
- add scopes to Menu model (order_by_asc_price / order_by_meal_type / seated / standing) /  add standing? and seated? class methods
- scope all chef in chef policy instead of chef that has active menus
- update validate_menu method in admin/menus_controller.rb to take limit active menus to 2 seated and 2 standing
- update index in controllers/chefs_controller.rb  to display chef that have active menus and 'standing menus if standing reservation' or 'seated menus if seated reservation'
- admin/chefs/show.slim : display seated menus and then standing menus
- app/views/chefs/show.slim : render seated menus list if reservation seated / standing menus list if reservation standing
