### PR TITLE
Cookoon filtering for new reservation

### DIFF
--- a/app/controllers/cookoons_controller.rb
+++ b/app/controllers/cookoons_controller.rb
@@ -8,7 +8,8 @@ class CookoonsController < ApplicationController
     filtering_params = {
       # accomodates_for: (@reservation.people_count),
       accomodates_for: (@reservation),
-      available_in: (@reservation.start_at..@reservation.end_at),
+      # available_in: (@reservation.start_at..@reservation.end_at),
+      available_in: (@reservation.start_at_for_chef_and_service..@reservation.end_at_for_chef_and_service),
       available_for: current_user
     }
 

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -24,7 +24,7 @@ class ReservationsController < ApplicationController
     if @reservation.save
       redirect_to reservation_cookoons_path(@reservation)
     else
-      flash.alert = "Oops, votre réservation n'est pas valide, vous devez remplir tous les champs"
+      flash.alert = "Votre réservation n'est pas valide, vous devez remplir tous les champs."
       redirect_to root_path
     end
   end

--- a/app/decorators/reservation_decorator.rb
+++ b/app/decorators/reservation_decorator.rb
@@ -149,7 +149,7 @@ class ReservationDecorator < Draper::Decorator
       breakfast: 'petit-déjeuner',
       lunch: 'déjeuner',
       diner: 'dîner',
-      diner_cocktail: 'cocktail dînatoire)',
+      diner_cocktail: 'cocktail dînatoire',
       lunch_cocktail: 'cocktail déjeunatoire',
       morning: 'matinée',
       day: 'journée',

--- a/app/frontend/style/override/bootstrap/_alert.scss
+++ b/app/frontend/style/override/bootstrap/_alert.scss
@@ -8,7 +8,7 @@
     background: $primary
   }
   &-danger {
-    background: $danger;
-    opacity: 0.25;
+    // background: $danger;
+    background: #CF7532;
   }
 }

--- a/app/models/concerns/dates_overlap_scope.rb
+++ b/app/models/concerns/dates_overlap_scope.rb
@@ -2,12 +2,19 @@ module DatesOverlapScope
   extend ActiveSupport::Concern
 
   class_methods do
+    # def overlapping(range)
+    #   return all if range.blank?
+    #   where(<<~SQL, range_start: range.first, range_end: range.last)
+    #     (start_at BETWEEN :range_start AND :range_end)
+    #     OR (end_at BETWEEN :range_start AND :range_end)
+    #     OR (start_at < :range_start AND :range_end < end_at)
+    #   SQL
+    # end
     def overlapping(range)
       return all if range.blank?
       where(<<~SQL, range_start: range.first, range_end: range.last)
-        (start_at BETWEEN :range_start AND :range_end)
-        OR (end_at BETWEEN :range_start AND :range_end)
-        OR (start_at < :range_start AND :range_end < end_at)
+        (:range_start BETWEEN start_at AND end_at)
+        OR (:range_end BETWEEN start_at AND end_at)
       SQL
     end
   end

--- a/app/models/concerns/reservation_state_machine.rb
+++ b/app/models/concerns/reservation_state_machine.rb
@@ -16,6 +16,7 @@ module ReservationStateMachine
       state :quotation_asked
       state :quotation_proposed
       state :quotation_accepted
+      state :quotation_refused
       state :refused
       state :cancelled
       state :ongoing
@@ -63,6 +64,10 @@ module ReservationStateMachine
 
       event :propose_quotation do
         transitions from: :quotation_asked, to: :quotation_proposed
+      end
+
+      event :refuse_quotation do
+        transitions from: :quotation_proposed, to: :quotation_refused
       end
 
       event :accept do

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -9,8 +9,10 @@ class Reservation < ApplicationRecord
   scope :for_tenant, ->(user) { where(user: user) }
   scope :for_host, ->(user) { where(cookoon: user.cookoons) }
   scope :active, -> { charged.or(accepted).or(ongoing).or(quotation_asked) }
-  scope :engaged, -> { accepted.or(ongoing) }
-  scope :inactive, -> { refused.or(passed) }
+  # scope :engaged, -> { accepted.or(ongoing) }
+  scope :engaged, -> { charged.or(accepted).or(menu_payment_captured).or(services_payment_captured).or(quotation_asked).or(quotation_proposed).or(quotation_accepted).or(ongoing) }
+  # scope :inactive, -> { refused.or(passed) }
+  scope :inactive, -> { refused.or(quotation_refused).or(passed).or(cancelled).or(dead)}
   scope :created_in_day_range_around, ->(datetime) { where created_at: day_range(datetime) }
   scope :in_hour_range_around, ->(datetime) { where start_at: hour_range(datetime) }
   scope :finished_in_day_range_around, ->(datetime) { joins(:inventory).merge(Inventory.checked_out_in_day_range_around(datetime)) }

--- a/app/views/host/users/dashboard.slim
+++ b/app/views/host/users/dashboard.slim
@@ -24,7 +24,7 @@
           en attente
 
       .pt-4.pb-3.text-right
-        = link_to 'Voir mes Réservations', host_reservations_path, class: 'btn-cookoon btn-cookoon-primary'
+        = link_to 'Voir mes demandes de réservation', host_reservations_path, class: 'btn-cookoon btn-cookoon-primary'
 
       hr
 


### PR DESCRIPTION
- Need to take account of start_at end end_at for chef and service when creating a new reservation
=> update overlapping(range) class method which is used to capture availibilities
=> update scope without_reservation_in for cookoons
=> update cookoon controller to filtering cookoon on range (start_at_for_chef_and_service..end_at_for_chef_and_service)

- update scopes engaged and inactive for cookoon with actual statuses

- many modifications:
=> background color of alert messages
=> add quotation refused as state of reservation + event corresponding
=> change one error message
=> change one name of button