### PR TITLE
Payment page part two

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -230,6 +230,18 @@ class Reservation < ApplicationRecord
     end_at + time_for_tidying
   end
 
+  def stripe_payment_intent_amount_cookoon_butler
+    stripe_payment_intent_amount(stripe_charge_id)
+  end
+
+  def stripe_payment_intent_amount_menu
+    stripe_payment_intent_amount(stripe_menu_id)
+  end
+
+  def stripe_payment_intent_amount_services
+    stripe_payment_intent_amount(stripe_services_id)
+  end
+
   private
 
   def configure_from_type_name
@@ -286,5 +298,9 @@ class Reservation < ApplicationRecord
 
   def time_for_tidying
     1.fdiv(3) * time_for_preparation_and_tidying
+  end
+
+  def stripe_payment_intent_amount(stripe_payment_intent)
+    Money.new(Stripe::PaymentIntent.retrieve(stripe_payment_intent).amount)
   end
 end

--- a/app/views/payments/_details_cookoon_butler.slim
+++ b/app/views/payments/_details_cookoon_butler.slim
@@ -21,6 +21,18 @@ p.mb-3.font-weight-bold 1. Votre décor et le service
         br
         i
           '(soit #{humanized_money_with_symbol(reservation.cookoon_butler_price)}HT)
-    //.d-flex.justify-content-end
-      i
-        '(soit #{humanized_money_with_symbol(reservation.cookoon_butler_price)}HT)
+
+  - if reservation.stripe_charge_id.present?
+    .d-flex.justify-content-between
+      div
+        - if reservation.cookoon_butler_payment_status == "charged"
+          b En attente de débit
+          br
+          i
+            '(Vous ne serez débité qu'après acceptation de votre réservation par l'hôte)
+        - elsif (reservation.cookoon_butler_payment_status == "captured" || reservation.cookoon_butler_payment_status == "paid")
+          b Déjà réglé
+        - elsif reservation.cookoon_butler_payment_status == "cancelled"
+          b Annulé
+      .text-right.text-nowrap
+        b #{humanized_money_with_symbol(reservation.stripe_payment_intent_amount_cookoon_butler)}TTC


### PR DESCRIPTION
- add reservation class methods to retrieve stripe payment intent amount
- update part of cookoon butler payment recap in new payment page to get different sentences depending on reservation statuses