### PR TITLE
Search disable dates + Dashboard user and host updated concerning reservations

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,6 +4,11 @@ class PagesController < ApplicationController
 
   def home
     @reservation = Reservation.new.decorate
+    @end_date_available = ((Time.zone.today + 5.weeks).beginning_of_week) - 1.days
+    @dates_with_no_cookoon_available = []
+    (Date.today..(Date.today + (7 * 5))).to_a.each do |date|
+      @dates_with_no_cookoon_available << date.strftime("%Y-%m-%d") if Cookoon.available_in_day(date).blank?
+    end
   end
 
   def support; end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,9 +4,9 @@ class PagesController < ApplicationController
 
   def home
     @reservation = Reservation.new.decorate
-    @end_date_available = ((Time.zone.today + 5.weeks).beginning_of_week) - 1.days
-    @dates_with_no_cookoon_available = []
-    (Date.today..(Date.today + (7 * 5))).to_a.each do |date|
+    @end_date_available = ((Date.today + Availability::SETTABLE_WEEKS_AHEAD.weeks).beginning_of_week) - 1.days
+    @dates_with_no_cookoon_available = Array.new
+    (Date.today..@end_date_available).to_a.each do |date|
       @dates_with_no_cookoon_available << date.strftime("%Y-%m-%d") if Cookoon.available_in_day(date).blank?
     end
   end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -6,8 +6,8 @@ class ReservationsController < ApplicationController
   def index
     # reservations = policy_scope(Reservation).includes(cookoon: :user)
     reservations = policy_scope(Reservation).includes(:cookoon)
-    @active_reservations = ReservationDecorator.decorate_collection(reservations.includes(:menu, :services).active)
-    @inactive_reservations = ReservationDecorator.decorate_collection(reservations.includes(:menu, :services).inactive)
+    @active_reservations = ReservationDecorator.decorate_collection(reservations.includes(:menu, :services).engaged)
+    @inactive_reservations = ReservationDecorator.decorate_collection(reservations.includes(:menu, :services).passed)
   end
 
   def show

--- a/app/frontend/components/search/_search.slim
+++ b/app/frontend/components/search/_search.slim
@@ -21,7 +21,7 @@
           - types.each do |type|
             .input-cookoon-search-selection-item data={type: type[:data], text: type[:display], action: 'click->search#selectType'} #{type[:display]}
 
-      .input-cookoon-search data={target: 'search.dateSelection'}
+      .input-cookoon-search data={target: 'search.dateSelection', 'end-date-available': @end_date_available, 'dates-with-no-cookoon-available': @dates_with_no_cookoon_available}
         p Date
         span.input-cookoon-search-data data={target: 'search.dateText'} = @reservation.default_date
 

--- a/app/frontend/components/search/search_controller.js
+++ b/app/frontend/components/search/search_controller.js
@@ -26,7 +26,12 @@ export default class extends Controller {
   connect() {
     flatpickr(this.dateSelectionTarget, {
       dateFormat: 'Y-m-dTH:i',
+      // disable: ["2020-11-30", "2020-12-09"],
+      disable: JSON.parse(this.dateSelectionTarget.getAttribute("data-dates-with-no-cookoon-available")),
       minDate: 'today',
+      maxDate: this.dateSelectionTarget.getAttribute("data-end-date-available"),
+      // not working if day is sunday
+      // maxDate: (new Date().fp_incr(5*7)).fp_incr(-((new Date().fp_incr(5*7)).getDay())),
       disableMobile: "true",
       onValueUpdate: (selectedDates, dateStr) => {
         this.selectDate(selectedDates, dateStr)

--- a/app/frontend/vendor/flatpickr/cookoon.css
+++ b/app/frontend/vendor/flatpickr/cookoon.css
@@ -441,6 +441,9 @@ span.flatpickr-weekday {
   background: transparent;
   border-color: var(--primary);
 }
+.flatpickr-day.flatpickr-disabled:hover {
+  border-color: transparent;;
+}
 .flatpickr-day.today {
   border-color: #fff;
 }
@@ -500,10 +503,11 @@ span.flatpickr-weekday {
 .flatpickr-day.disabled,
 .flatpickr-day.disabled:hover,
 .flatpickr-day.prevMonthDay,
-.flatpickr-day.nextMonthDay,
+/*.flatpickr-day.nextMonthDay,*/
 .flatpickr-day.notAllowed,
 .flatpickr-day.notAllowed.prevMonthDay,
-.flatpickr-day.notAllowed.nextMonthDay {
+.flatpickr-day.notAllowed.nextMonthDay,
+.flatpickr-disabled {
   color: rgba(0, 66, 84, 0.3);
   background: transparent;
   border-color: transparent;

--- a/app/models/cookoon.rb
+++ b/app/models/cookoon.rb
@@ -16,6 +16,7 @@ class Cookoon < ApplicationRecord
   scope :available_for, ->(user) { where.not(user: user) }
   scope :available_in, ->(range) { without_reservation_in(range).without_availability_in(range) }
   # scope :without_reservation_in, ->(range) { where.not(id: Reservation.engaged.overlapping(range).pluck(:cookoon_id).uniq) }
+  scope :available_in_day, -> (day) { approved.displayable_on_index.available_in((day.in_time_zone.beginning_of_day + 2.hours)..(day.in_time_zone.end_of_day)) }
   scope :without_reservation_in, ->(range) { where.not(id: Reservation.engaged.map { |reservation| { cookoon_id: reservation.cookoon_id, start_at_for_chef_and_service: reservation.start_at_for_chef_and_service, end_at_for_chef_and_service: reservation.end_at_for_chef_and_service } }.select { |reservation| (reservation[:start_at_for_chef_and_service] >= range.first && reservation[:start_at_for_chef_and_service] <= range.last) || (reservation[:end_at_for_chef_and_service] >= range.first && reservation[:end_at_for_chef_and_service] <= range.last) }.pluck(:cookoon_id).uniq) }
   scope :without_availability_in, ->(range) { where.not(id: Availability.unavailable.overlapping(range).pluck(:cookoon_id).uniq) }
   scope :created_in_day_range_around, ->(date_time) { where created_at: day_range(date_time) }

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -8,11 +8,11 @@ class Reservation < ApplicationRecord
   scope :displayable, -> { where.not(aasm_state: :initial).order(start_at: :asc) }
   scope :for_tenant, ->(user) { where(user: user) }
   scope :for_host, ->(user) { where(cookoon: user.cookoons) }
-  scope :active, -> { charged.or(accepted).or(ongoing).or(quotation_asked).or(quotation_proposed).or(quotation_accepted) }
+  # scope :active, -> { charged.or(accepted).or(ongoing).or(quotation_asked).or(quotation_proposed).or(quotation_accepted) }
   # scope :engaged, -> { accepted.or(ongoing) }
   scope :engaged, -> { charged.or(accepted).or(menu_payment_captured).or(services_payment_captured).or(quotation_asked).or(quotation_proposed).or(quotation_accepted).or(ongoing) }
   # scope :inactive, -> { refused.or(passed) }
-  scope :inactive, -> { refused.or(quotation_refused).or(passed).or(cancelled)}
+  scope :inactive, -> { refused.or(quotation_refused).or(passed).or(cancelled).or(dead)}
   scope :created_in_day_range_around, ->(datetime) { where created_at: day_range(datetime) }
   scope :in_hour_range_around, ->(datetime) { where start_at: hour_range(datetime) }
   scope :finished_in_day_range_around, ->(datetime) { joins(:inventory).merge(Inventory.checked_out_in_day_range_around(datetime)) }


### PR DESCRIPTION
- Search disable dates : 
=> add css for disabled dates (no circle around on hover and lightgray color)
=> disable dates where no cookoon available on day + dates after five weeks (sunday before) to match with host availabilities board

- Dashboard user and host reservations
=> display reservations engaged in "En cours" and reservations passed in "Passées"