### PR TITLE
Job cancellation reservation

### DIFF
--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -15,7 +15,8 @@ module Admin
       @engaged_reservations_that_needs_user_action = engaged_reservations.needs_user_action
       @passed_reservations = engaged_reservations.starting_before_today + reservations.passed
       @reservations_refused_by_host = reservations.refused_by_host
-      # @cancelled_reservations_because_host_did_not_reply = reservations.cancelled_because_host_did_not_reply_in_validity_period
+      # @cancelled_reservations_because_host_did_not_reply_in_validity_period = reservations.cancelled_because_host_did_not_reply_in_validity_period
+      # @cancelled_reservations_because_short_notice = reservations.cancelled_because_short_notice
 
       # @engaged_customer_reservations = reservations.customer.engaged_credit_card_payment
       # @engaged_business_with_credit_card_payment_reservations = reservations.business.engaged_credit_card_payment

--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -15,7 +15,7 @@ module Admin
       @engaged_reservations_that_needs_user_action = engaged_reservations.needs_user_action
       @passed_reservations = engaged_reservations.starting_before_today + reservations.passed
       @reservations_refused_by_host = reservations.refused_by_host
-      # @cancelled_reservations_because_host_did_not_reply = reservations.cancelled
+      # @cancelled_reservations_because_host_did_not_reply = reservations.cancelled_because_host_did_not_reply
 
       # @engaged_customer_reservations = reservations.customer.engaged_credit_card_payment
       # @engaged_business_with_credit_card_payment_reservations = reservations.business.engaged_credit_card_payment

--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -15,7 +15,7 @@ module Admin
       @engaged_reservations_that_needs_user_action = engaged_reservations.needs_user_action
       @passed_reservations = engaged_reservations.starting_before_today + reservations.passed
       @reservations_refused_by_host = reservations.refused_by_host
-      # @cancelled_reservations_because_host_did_not_reply = reservations.cancelled_because_host_did_not_reply
+      # @cancelled_reservations_because_host_did_not_reply = reservations.cancelled_because_host_did_not_reply_in_validity_period
 
       # @engaged_customer_reservations = reservations.customer.engaged_credit_card_payment
       # @engaged_business_with_credit_card_payment_reservations = reservations.business.engaged_credit_card_payment

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -37,12 +37,12 @@ class ReservationsController < ApplicationController
     end
   end
 
-  def update
-    @reservation.cancelled!
-    # ReservationMailer.cancelled_by_tenant_to_tenant(@reservation).deliver_later
-    # ReservationMailer.cancelled_by_tenant_to_host(@reservation).deliver_later
-    redirect_to reservations_path
-  end
+  # def update
+  #   @reservation.cancelled!
+  #   # ReservationMailer.cancelled_by_tenant_to_tenant(@reservation).deliver_later
+  #   # ReservationMailer.cancelled_by_tenant_to_host(@reservation).deliver_later
+  #   redirect_to reservations_path
+  # end
 
   def select_cookoon
     if @reservation.pending?

--- a/app/jobs/reservations_cleanup_job.rb
+++ b/app/jobs/reservations_cleanup_job.rb
@@ -4,7 +4,8 @@ class ReservationsCleanupJob < ApplicationJob
   def perform
     cleanup_dropped_before_payment
     cleanup_short_notice
-    cleanup_stripe_will_not_capture
+    # cleanup_stripe_will_not_capture
+    cleanup_host_did_not_reply_in_validity_period
   end
 
   private
@@ -20,11 +21,17 @@ class ReservationsCleanupJob < ApplicationJob
     end
   end
 
-  def cleanup_stripe_will_not_capture
-    Reservation.stripe_will_not_capture.each do |reservation|
-      reservation.cancel!
-      # ReservationMailer.autocancel_stripe_period_to_tenant(reservation).deliver_later
-      # ReservationMailer.autocancel_stripe_period_to_host(reservation).deliver_later
+  # def cleanup_stripe_will_not_capture
+  #   Reservation.stripe_will_not_capture.each do |reservation|
+  #     reservation.cancel!
+  #     # ReservationMailer.autocancel_stripe_period_to_tenant(reservation).deliver_later
+  #     # ReservationMailer.autocancel_stripe_period_to_host(reservation).deliver_later
+  #   end
+  # end
+
+  def cleanup_host_did_not_reply_in_validity_period
+    Reservation.host_did_not_reply_in_validity_period.each do |reservation|
+      reservation.cancel_because_host_did_not_reply_in_validity_period!
     end
   end
 end

--- a/app/jobs/reservations_cleanup_job.rb
+++ b/app/jobs/reservations_cleanup_job.rb
@@ -16,7 +16,7 @@ class ReservationsCleanupJob < ApplicationJob
 
   def cleanup_short_notice
     Reservation.short_notice.each do |reservation|
-      reservation.cancel!
+      reservation.cancel_because_short_notice!
       # ReservationMailer.autocancel_short_notice_to_tenant(reservation).deliver_later
     end
   end

--- a/app/models/concerns/reservation_state_machine.rb
+++ b/app/models/concerns/reservation_state_machine.rb
@@ -22,6 +22,7 @@ module ReservationStateMachine
       state :refused
       # state :cancelled
       state :cancelled_because_host_did_not_reply_in_validity_period
+      state :cancelled_because_short_notice
       state :ongoing
       state :passed
       state :dead
@@ -99,6 +100,10 @@ module ReservationStateMachine
 
       event :cancel_because_host_did_not_reply_in_validity_period do
         transitions from: [:charged, :quotation_asked], to: :cancelled_because_host_did_not_reply_in_validity_period
+      end
+
+      event :cancel_because_short_notice do
+        transitions from: [:charged, :quotation_asked], to: :cancelled_because_short_notice
       end
 
       event :start do

--- a/app/models/concerns/reservation_state_machine.rb
+++ b/app/models/concerns/reservation_state_machine.rb
@@ -21,7 +21,7 @@ module ReservationStateMachine
       state :quotation_refused
       state :refused
       # state :cancelled
-      state :cancelled_because_host_did_not_reply
+      state :cancelled_because_host_did_not_reply_in_validity_period
       state :ongoing
       state :passed
       state :dead
@@ -97,8 +97,8 @@ module ReservationStateMachine
       #   transitions from: [:initial, :cookoon_selected, :menu_selected, :services_selected, :charged, :quotation_asked, :quotation_proposed], to: :cancelled
       # end
 
-      event :cancel_because_host_did_not_reply do
-        transitions from: [:charged, :quotation_asked], to: :cancelled_because_host_did_not_reply
+      event :cancel_because_host_did_not_reply_in_validity_period do
+        transitions from: [:charged, :quotation_asked], to: :cancelled_because_host_did_not_reply_in_validity_period
       end
 
       event :start do

--- a/app/models/concerns/reservation_state_machine.rb
+++ b/app/models/concerns/reservation_state_machine.rb
@@ -20,7 +20,8 @@ module ReservationStateMachine
       state :quotation_accepted
       state :quotation_refused
       state :refused
-      state :cancelled
+      # state :cancelled
+      state :cancelled_because_host_did_not_reply
       state :ongoing
       state :passed
       state :dead
@@ -92,8 +93,12 @@ module ReservationStateMachine
         transitions from: :charged, to: :refused
       end
 
-      event :cancel do
-        transitions from: [:initial, :cookoon_selected, :menu_selected, :services_selected, :charged, :quotation_asked, :quotation_proposed], to: :cancelled
+      # event :cancel do
+      #   transitions from: [:initial, :cookoon_selected, :menu_selected, :services_selected, :charged, :quotation_asked, :quotation_proposed], to: :cancelled
+      # end
+
+      event :cancel_because_host_did_not_reply do
+        transitions from: [:charged, :quotation_asked], to: :cancelled_because_host_did_not_reply
       end
 
       event :start do

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -18,7 +18,7 @@ class Reservation < ApplicationRecord
   # scope :engaged, -> { charged.or(accepted).or(menu_payment_captured).or(services_payment_captured).or(quotation_asked).or(quotation_accepted_by_host).or(quotation_proposed).or(quotation_accepted).or(ongoing) }
   # scope :inactive, -> { refused.or(passed) }
   scope :refused_by_host, -> { refused.or(quotation_refused_by_host) }
-  scope :inactive, -> { refused.or(quotation_refused_by_host).or(quotation_refused).or(passed).or(cancelled).or(dead)}
+  scope :inactive, -> { refused.or(quotation_refused_by_host).or(quotation_refused).or(passed).or(cancelled_because_host_did_not_reply).or(dead)}
   scope :created_in_day_range_around, ->(datetime) { where created_at: day_range(datetime) }
   scope :in_hour_range_around, ->(datetime) { where start_at: hour_range(datetime) }
   scope :finished_in_day_range_around, ->(datetime) { joins(:inventory).merge(Inventory.checked_out_in_day_range_around(datetime)) }
@@ -96,7 +96,7 @@ class Reservation < ApplicationRecord
   validates :type_name, inclusion: { in: %w[breakfast brunch lunch diner diner_cocktail lunch_cocktail morning afternoon day], message: "Ce type de réservation n'est pas valide" }
   validates :menu_status, inclusion: { in: %w[initial selected cooking_by_user validated payment_required captured paid], message: "Le statut du menu n'est pas valide" }
   validates :services_status, inclusion: { in: %w[initial validated payment_required captured paid], message: "Le statut n'est pas valide" }
-  validates :cookoon_butler_payment_status, inclusion: { in: %w[initial charged captured cancelled paid] }
+  validates :cookoon_butler_payment_status, inclusion: { in: %w[initial charged captured cancelled_because_host_did_not_reply paid] }
 
   validate :tenant_is_not_host
 
@@ -124,9 +124,9 @@ class Reservation < ApplicationRecord
     initial? || paid
   end
 
-  def refused_passed_or_cancelled?
-    refused? || passed? #|| cancelled? Uncomment when implementing cancel
-  end
+  # def refused_passed_or_cancelled?
+  #   refused? || passed? #|| cancelled? Uncomment when implementing cancel
+  # end
 
   def payment(options = {})
     @payment ||= Reservation::Payment.new(self, options)
@@ -332,7 +332,7 @@ class Reservation < ApplicationRecord
   end
 
   def notification_needed?
-    %w(charged accepted menu_payment_captured services_payment_captured quotation_asked quotation_accepted_by_host quotation_refused_by_host quotation_proposed quotation_accepted quotation_refused refused cancelled ongoing passed).include? aasm_state
+    %w(charged accepted menu_payment_captured services_payment_captured quotation_asked quotation_accepted_by_host quotation_refused_by_host quotation_proposed quotation_accepted quotation_refused refused cancelled_because_host_did_not_reply ongoing passed).include? aasm_state
   end
 
   def tenant_is_not_host

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -30,7 +30,8 @@ class Reservation < ApplicationRecord
   scope :pending, -> { initial.or(cookoon_selected).or(menu_selected).or(services_selected) }
   scope :dropped_before_payment, -> { pending.created_before(DEFAULTS[:safety_period].ago) }
   scope :paid, -> { where(paid: true) }
-  scope :short_notice, -> { paid.where('start_at < ?', Time.zone.now.in(DEFAULTS[:safety_period])) }
+  # scope :short_notice, -> { paid.where('start_at < ?', Time.zone.now.in(DEFAULTS[:safety_period])) }
+  scope :short_notice, -> { charged.or(quotation_asked).where('start_at < ?', Time.zone.now.in(DEFAULTS[:safety_period])) }
   scope :stripe_will_not_capture, -> { paid.created_before(DEFAULTS[:stripe_validity_period].ago.in(DEFAULTS[:safety_period])) }
   scope :host_did_not_reply_in_validity_period, -> { charged.or(quotation_asked).created_before(DEFAULTS[:validity_period].ago) }
 

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -18,7 +18,7 @@ class Reservation < ApplicationRecord
   # scope :engaged, -> { charged.or(accepted).or(menu_payment_captured).or(services_payment_captured).or(quotation_asked).or(quotation_accepted_by_host).or(quotation_proposed).or(quotation_accepted).or(ongoing) }
   # scope :inactive, -> { refused.or(passed) }
   scope :refused_by_host, -> { refused.or(quotation_refused_by_host) }
-  scope :inactive, -> { refused.or(quotation_refused_by_host).or(quotation_refused).or(passed).or(cancelled_because_host_did_not_reply_in_validity_period).or(dead)}
+  scope :inactive, -> { refused.or(quotation_refused_by_host).or(quotation_refused).or(passed).or(cancelled_because_host_did_not_reply_in_validity_period).or(cancelled_because_short_notice).or(dead)}
   scope :created_in_day_range_around, ->(datetime) { where created_at: day_range(datetime) }
   scope :in_hour_range_around, ->(datetime) { where start_at: hour_range(datetime) }
   scope :finished_in_day_range_around, ->(datetime) { joins(:inventory).merge(Inventory.checked_out_in_day_range_around(datetime)) }
@@ -98,7 +98,7 @@ class Reservation < ApplicationRecord
   validates :type_name, inclusion: { in: %w[breakfast brunch lunch diner diner_cocktail lunch_cocktail morning afternoon day], message: "Ce type de réservation n'est pas valide" }
   validates :menu_status, inclusion: { in: %w[initial selected cooking_by_user validated payment_required captured paid], message: "Le statut du menu n'est pas valide" }
   validates :services_status, inclusion: { in: %w[initial validated payment_required captured paid], message: "Le statut n'est pas valide" }
-  validates :cookoon_butler_payment_status, inclusion: { in: %w[initial charged captured cancelled_because_host_did_not_reply_in_validity_period paid] }
+  validates :cookoon_butler_payment_status, inclusion: { in: %w[initial charged captured cancelled paid] }
 
   validate :tenant_is_not_host
 
@@ -334,7 +334,7 @@ class Reservation < ApplicationRecord
   end
 
   def notification_needed?
-    %w(charged accepted menu_payment_captured services_payment_captured quotation_asked quotation_accepted_by_host quotation_refused_by_host quotation_proposed quotation_accepted quotation_refused refused cancelled_because_host_did_not_reply_in_validity_period ongoing passed).include? aasm_state
+    %w(charged accepted menu_payment_captured services_payment_captured quotation_asked quotation_accepted_by_host quotation_refused_by_host quotation_proposed quotation_accepted quotation_refused refused cancelled_because_host_did_not_reply_in_validity_period cancelled_because_short_notice ongoing passed).include? aasm_state
   end
 
   def tenant_is_not_host

--- a/app/policies/reservation_policy.rb
+++ b/app/policies/reservation_policy.rb
@@ -16,9 +16,9 @@ class ReservationPolicy < ApplicationPolicy
     end
   end
 
-  def update?
-    record.user == user
-  end
+  # def update?
+  #   record.user == user
+  # end
 
   def amounts?
     record.user == user

--- a/app/services/slack/reservation_notifier.rb
+++ b/app/services/slack/reservation_notifier.rb
@@ -60,7 +60,7 @@ module Slack
       when :passed
         "[FIN] la location pour #{cookoon.name} par #{tenant.full_name} vient de se terminer.
         #{url_for_admin_reservation}"
-      when :cancelled_because_host_did_not_reply
+      when :cancelled_because_host_did_not_reply_in_validity_period
         "[ANNULATION] la location pour #{cookoon.name} le #{formatted_date} vient d'être annulée car l'hôte n'a pas répondu dans les temps.
         #{url_for_admin_reservation}"
       end

--- a/app/services/slack/reservation_notifier.rb
+++ b/app/services/slack/reservation_notifier.rb
@@ -63,7 +63,7 @@ module Slack
       when :cancelled_because_host_did_not_reply_in_validity_period
         "[ANNULATION] la location pour #{cookoon.name} le #{formatted_date} vient d'être annulée car l'hôte n'a pas répondu dans les temps.
         #{url_for_admin_reservation}"
-      when :cancelled_because_short_notice)
+      when :cancelled_because_short_notice
         "[ANNULATION] la location pour #{cookoon.name} le #{formatted_date} vient d'être annulée car le délai est trop court.
       end
     end

--- a/app/services/slack/reservation_notifier.rb
+++ b/app/services/slack/reservation_notifier.rb
@@ -63,6 +63,8 @@ module Slack
       when :cancelled_because_host_did_not_reply_in_validity_period
         "[ANNULATION] la location pour #{cookoon.name} le #{formatted_date} vient d'être annulée car l'hôte n'a pas répondu dans les temps.
         #{url_for_admin_reservation}"
+      when :cancelled_because_short_notice)
+        "[ANNULATION] la location pour #{cookoon.name} le #{formatted_date} vient d'être annulée car le délai est trop court.
       end
     end
 

--- a/app/services/slack/reservation_notifier.rb
+++ b/app/services/slack/reservation_notifier.rb
@@ -60,8 +60,8 @@ module Slack
       when :passed
         "[FIN] la location pour #{cookoon.name} par #{tenant.full_name} vient de se terminer.
         #{url_for_admin_reservation}"
-      when :cancelled
-        "[ANNULATION] la location pour #{cookoon.name} le #{formatted_date} vient d'être annulée.
+      when :cancelled_because_host_did_not_reply
+        "[ANNULATION] la location pour #{cookoon.name} le #{formatted_date} vient d'être annulée car l'hôte n'a pas répondu dans les temps.
         #{url_for_admin_reservation}"
       end
     end

--- a/app/services/slack/reservation_notifier.rb
+++ b/app/services/slack/reservation_notifier.rb
@@ -65,6 +65,7 @@ module Slack
         #{url_for_admin_reservation}"
       when :cancelled_because_short_notice
         "[ANNULATION] la location pour #{cookoon.name} le #{formatted_date} vient d'être annulée car le délai est trop court.
+        #{url_for_admin_reservation}"
       end
     end
 

--- a/app/views/payments/_details_cookoon_butler.slim
+++ b/app/views/payments/_details_cookoon_butler.slim
@@ -22,7 +22,7 @@ p.mb-3.font-weight-bold 1. Votre décor et le service
   - if reservation.refused?
     = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:cancelled], sentence_two: "", amount_ttc: reservation.stripe_payment_intent_amount_cookoon_butler, amount_ht: ""
 
-  - if reservation.cancelled_because_host_did_not_reply? || reservation.dead?
+  - if reservation.cancelled_because_host_did_not_reply_in_validity_period? || reservation.dead?
     = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:cancelled], sentence_two: "", amount_ttc: reservation.cookoon_butler_with_tax, amount_ht: ""
 
   - if reservation.quotation_asked?

--- a/app/views/payments/_details_cookoon_butler.slim
+++ b/app/views/payments/_details_cookoon_butler.slim
@@ -22,7 +22,7 @@ p.mb-3.font-weight-bold 1. Votre décor et le service
   - if reservation.refused?
     = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:cancelled], sentence_two: "", amount_ttc: reservation.stripe_payment_intent_amount_cookoon_butler, amount_ht: ""
 
-  - if reservation.cancelled_because_host_did_not_reply_in_validity_period? || reservation.dead?
+  - if reservation.cancelled_because_host_did_not_reply_in_validity_period? || reservation.cancelled_because_short_notice || reservation.dead?
     = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:cancelled], sentence_two: "", amount_ttc: reservation.cookoon_butler_with_tax, amount_ht: ""
 
   - if reservation.quotation_asked?

--- a/app/views/payments/_details_cookoon_butler.slim
+++ b/app/views/payments/_details_cookoon_butler.slim
@@ -22,7 +22,7 @@ p.mb-3.font-weight-bold 1. Votre décor et le service
   - if reservation.refused?
     = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:cancelled], sentence_two: "", amount_ttc: reservation.stripe_payment_intent_amount_cookoon_butler, amount_ht: ""
 
-  - if reservation.cancelled? || reservation.dead?
+  - if reservation.cancelled_because_host_did_not_reply? || reservation.dead?
     = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:cancelled], sentence_two: "", amount_ttc: reservation.cookoon_butler_with_tax, amount_ht: ""
 
   - if reservation.quotation_asked?

--- a/app/views/payments/_details_menu.slim
+++ b/app/views/payments/_details_menu.slim
@@ -22,7 +22,7 @@ p.mb-3.font-weight-bold 2. Vos souhaits de chef et de menu
     - if reservation.menu_payment_captured? || reservation.services_payment_captured?
       = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:paid], sentence_two: "", amount_ttc: reservation.stripe_payment_intent_amount_menu, amount_ht: ""
 
-    - if reservation.refused? || reservation.cancelled_because_host_did_not_reply_in_validity_period? || reservation.dead?
+    - if reservation.refused? || reservation.cancelled_because_host_did_not_reply_in_validity_period? || reservation.cancelled_because_short_notice || reservation.dead?
       = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:cancelled], sentence_two: "", amount_ttc: reservation.menu_with_tax, amount_ht: ""
 
     - if reservation.quotation_asked?

--- a/app/views/payments/_details_menu.slim
+++ b/app/views/payments/_details_menu.slim
@@ -22,7 +22,7 @@ p.mb-3.font-weight-bold 2. Vos souhaits de chef et de menu
     - if reservation.menu_payment_captured? || reservation.services_payment_captured?
       = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:paid], sentence_two: "", amount_ttc: reservation.stripe_payment_intent_amount_menu, amount_ht: ""
 
-    - if reservation.refused? || reservation.cancelled? || reservation.dead?
+    - if reservation.refused? || reservation.cancelled_because_host_did_not_reply? || reservation.dead?
       = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:cancelled], sentence_two: "", amount_ttc: reservation.menu_with_tax, amount_ht: ""
 
     - if reservation.quotation_asked?

--- a/app/views/payments/_details_menu.slim
+++ b/app/views/payments/_details_menu.slim
@@ -22,7 +22,7 @@ p.mb-3.font-weight-bold 2. Vos souhaits de chef et de menu
     - if reservation.menu_payment_captured? || reservation.services_payment_captured?
       = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:paid], sentence_two: "", amount_ttc: reservation.stripe_payment_intent_amount_menu, amount_ht: ""
 
-    - if reservation.refused? || reservation.cancelled_because_host_did_not_reply? || reservation.dead?
+    - if reservation.refused? || reservation.cancelled_because_host_did_not_reply_in_validity_period? || reservation.dead?
       = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:cancelled], sentence_two: "", amount_ttc: reservation.menu_with_tax, amount_ht: ""
 
     - if reservation.quotation_asked?

--- a/app/views/payments/_details_services.slim
+++ b/app/views/payments/_details_services.slim
@@ -33,7 +33,7 @@ p.mb-3.font-weight-bold 3. Vos souhaits de service
     - if reservation.services_payment_captured?
       = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:paid], sentence_two: "", amount_ttc: reservation.stripe_payment_intent_amount_services, amount_ht: ""
 
-    - if reservation.refused? || reservation.cancelled_because_host_did_not_reply_in_validity_period? || reservation.dead?
+    - if reservation.refused? || reservation.cancelled_because_host_did_not_reply_in_validity_period? || reservation.cancelled_because_short_notice || reservation.dead?
       = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:cancelled], sentence_two: "", amount_ttc: "", amount_ht: ""
 
     - if reservation.quotation_asked?

--- a/app/views/payments/_details_services.slim
+++ b/app/views/payments/_details_services.slim
@@ -33,7 +33,7 @@ p.mb-3.font-weight-bold 3. Vos souhaits de service
     - if reservation.services_payment_captured?
       = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:paid], sentence_two: "", amount_ttc: reservation.stripe_payment_intent_amount_services, amount_ht: ""
 
-    - if reservation.refused? || reservation.cancelled_because_host_did_not_reply? || reservation.dead?
+    - if reservation.refused? || reservation.cancelled_because_host_did_not_reply_in_validity_period? || reservation.dead?
       = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:cancelled], sentence_two: "", amount_ttc: "", amount_ht: ""
 
     - if reservation.quotation_asked?

--- a/app/views/payments/_details_services.slim
+++ b/app/views/payments/_details_services.slim
@@ -33,7 +33,7 @@ p.mb-3.font-weight-bold 3. Vos souhaits de service
     - if reservation.services_payment_captured?
       = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:paid], sentence_two: "", amount_ttc: reservation.stripe_payment_intent_amount_services, amount_ht: ""
 
-    - if reservation.refused? || reservation.cancelled? || reservation.dead?
+    - if reservation.refused? || reservation.cancelled_because_host_did_not_reply? || reservation.dead?
       = render 'payments/amounts_details', sentence_one: Payment::STATUSES[:cancelled], sentence_two: "", amount_ttc: "", amount_ht: ""
 
     - if reservation.quotation_asked?

--- a/app/views/payments/new.slim
+++ b/app/views/payments/new.slim
@@ -25,7 +25,7 @@
 
       = render 'payments/details_services', reservation: @reservation
 
-      - if !@reservation.cancelled_because_host_did_not_reply? && !@reservation.refused? && !@reservation.dead? && !@reservation.quotation_asked? && !@reservation.quotation_proposed? && !@reservation.quotation_accepted? && !@reservation.quotation_refused?
+      - if !@reservation.cancelled_because_host_did_not_reply_in_validity_period? && !@reservation.refused? && !@reservation.dead? && !@reservation.quotation_asked? && !@reservation.quotation_proposed? && !@reservation.quotation_accepted? && !@reservation.quotation_refused?
         hr.my-5
 
         = render 'payments/details_total', reservation: @reservation

--- a/app/views/payments/new.slim
+++ b/app/views/payments/new.slim
@@ -25,7 +25,7 @@
 
       = render 'payments/details_services', reservation: @reservation
 
-      - if !@reservation.cancelled? && !@reservation.refused? && !@reservation.dead? && !@reservation.quotation_asked? && !@reservation.quotation_proposed? && !@reservation.quotation_accepted? && !@reservation.quotation_refused?
+      - if !@reservation.cancelled_because_host_did_not_reply? && !@reservation.refused? && !@reservation.dead? && !@reservation.quotation_asked? && !@reservation.quotation_proposed? && !@reservation.quotation_accepted? && !@reservation.quotation_refused?
         hr.my-5
 
         = render 'payments/details_total', reservation: @reservation

--- a/app/views/payments/new.slim
+++ b/app/views/payments/new.slim
@@ -25,7 +25,7 @@
 
       = render 'payments/details_services', reservation: @reservation
 
-      - if !@reservation.cancelled_because_host_did_not_reply_in_validity_period? && !@reservation.refused? && !@reservation.dead? && !@reservation.quotation_asked? && !@reservation.quotation_proposed? && !@reservation.quotation_accepted? && !@reservation.quotation_refused?
+      - if !@reservation.cancelled_because_host_did_not_reply_in_validity_period? && !reservation.cancelled_because_short_notice && !@reservation.refused? && !@reservation.dead? && !@reservation.quotation_asked? && !@reservation.quotation_proposed? && !@reservation.quotation_accepted? && !@reservation.quotation_refused?
         hr.my-5
 
         = render 'payments/details_total', reservation: @reservation

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
   end
 
   # resources :reservations, only: %i[index show new create update] do
-  resources :reservations, only: %i[index new create update] do
+  resources :reservations, only: %i[index new create] do
     resources :cookoons, only: %i[index show] do
       resources :payments, only: [] do
         post :amounts, on: :collection

--- a/spec/factories/reservations.rb
+++ b/spec/factories/reservations.rb
@@ -10,6 +10,10 @@ FactoryBot.define do
       paid true
     end
 
+    trait :charged do
+      aasm_state "charged"
+    end
+
     trait :created_two_days_ago do
       created_at { 2.days.ago }
     end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Reservation, type: :model do
     let!(:paid) { create(:reservation, :paid) }
     let!(:two_days_ago) { create(:reservation, :created_two_days_ago) }
     let!(:paid_ten_days_ago) { create(:reservation, :paid, :created_ten_days_ago) }
+    let!(:charged) { create(:reservation, :charged ) }
 
     let!(:reservation_initial_with_menu) { create(:reservation, :with_menu) }
     let!(:reservation_charged_with_menu_selected) { create(:reservation, :with_menu, aasm_state: 'charged', menu_status: "selected") }
@@ -54,7 +55,7 @@ RSpec.describe Reservation, type: :model do
     end
 
     describe '.short_notice' do
-      let!(:paid) { create(:reservation, :paid) }
+      let!(:paid) { create(:reservation, :charged) }
 
       it 'returns only paid reservations starting in less than few hours' do
         Timecop.freeze(10.days.from_now) do
@@ -110,7 +111,7 @@ RSpec.describe Reservation, type: :model do
     describe '.with_services' do
       it 'returns only reservations with services' do
         expect(described_class.with_services).to include(reservation_initial_with_services)
-        expect((described_class.with_services).count).to eq(16)
+        expect((described_class.with_services).count).to eq(17)
       end
     end
 
@@ -118,7 +119,7 @@ RSpec.describe Reservation, type: :model do
       it 'returns only reservations which needs services validation' do
         expect(described_class.needs_services_validation).to include(reservation_charged_with_services)
         expect(described_class.needs_services_validation).to_not include(reservation_initial_with_services)
-        expect((described_class.needs_services_validation).count).to eq(6)
+        expect((described_class.needs_services_validation).count).to eq(7)
       end
     end
 
@@ -141,7 +142,7 @@ RSpec.describe Reservation, type: :model do
     describe '.needs_host_action' do
       it 'returns only reservations which needs host action' do
         expect(described_class.needs_host_action).to include(reservation_charged_with_menu_selected, reservation_charged_with_services)
-        expect((described_class.needs_host_action).count).to eq(2)
+        expect((described_class.needs_host_action).count).to eq(3)
       end
     end
 
@@ -155,7 +156,7 @@ RSpec.describe Reservation, type: :model do
     describe '.needs_admin_action_for_services' do
       it 'returns only reservations which needs admin action for services' do
         expect(described_class.needs_admin_action_for_services).to include(reservation_charged_with_menu_selected, reservation_accepted_with_menu_validated, reservation_accepted_with_menu_payment_required, reservation_charged_with_services, reservation_accepted_and_cooked_by_user_with_services, reservation_menu_payment_captured_with_services, reservation_accepted_and_cooked_by_user_with_services_validated, reservation_menu_payment_captured_with_services_validated)
-        expect((described_class.needs_admin_action_for_services).count).to eq(8)
+        expect((described_class.needs_admin_action_for_services).count).to eq(9)
       end
     end
 
@@ -176,7 +177,7 @@ RSpec.describe Reservation, type: :model do
     describe '.needs_admin_action' do
       it 'returns only reservations which needs admin action for menu and services' do
         expect(described_class.needs_admin_action).to include(reservation_charged_with_menu_selected, reservation_accepted_with_menu_validated, reservation_accepted_with_menu_payment_required, reservation_charged_with_services, reservation_accepted_and_cooked_by_user_with_services, reservation_menu_payment_captured_with_services, reservation_accepted_and_cooked_by_user_with_services_validated, reservation_menu_payment_captured_with_services_validated)
-        expect((described_class.needs_admin_action).count).to eq(8)
+        expect((described_class.needs_admin_action).count).to eq(9)
       end
     end
 


### PR DESCRIPTION
- add statuses and corresponding event : cancelled_because_host_did_not_reply_in_validity_period + cancelled_because_short_notice
- update scope short_notice + add scope host_did_not_reply_in_validity_period
- update rspec reservation model testing scope short_notice
- replace cancelled status by cancelled_because_host_did_not_reply_in_validity_period & cancelled_because_short_notice in views / model / slack messages
- remove reservation #update in controller and routes
- replace job cleanup_stripe_will_not_capture by job cleanup_host_did_not_reply_in_validity_period + update job cleanup_short_notice