### PR TITLE
Associations scopes chefs#index

### DIFF
--- a/app/controllers/chefs_controller.rb
+++ b/app/controllers/chefs_controller.rb
@@ -8,9 +8,9 @@ class ChefsController < ApplicationController
     # # policy_scope displays chef that only have active menus thanks to scope.has_active_menus in chef policy
     # @chefs = policy_scope(Chef).includes(:main_photo_files, :chef_perks, chef_perks: :chef_perk_specification)
     if @reservation.seated?
-      @chefs = policy_scope(Chef).has_active_seated_menus.includes(:main_photo_files, :chef_perks, chef_perks: :chef_perk_specification)
+      @chefs = policy_scope(Chef).has_active_seated_menus.without_engaged_reservations_in_day(@reservation.start_at).includes(:main_photo_files, :chef_perks, chef_perks: :chef_perk_specification)
     elsif @reservation.standing?
-      @chefs = policy_scope(Chef).has_active_standing_menus.includes(:main_photo_files, :chef_perks, chef_perks: :chef_perk_specification)
+      @chefs = policy_scope(Chef).has_active_standing_menus.without_engaged_reservations_in_day(@reservation.start_at).includes(:main_photo_files, :chef_perks, chef_perks: :chef_perk_specification)
     else
       @chefs = policy_scope(Chef).none
     end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -22,7 +22,9 @@ class PagesController < ApplicationController
   def set_dates_with_no_cookoon_available_for_current_user
     @dates_with_no_cookoon_available_for_current_user = Array.new
     (Date.today..@end_date_available).to_a.each do |date|
-      @dates_with_no_cookoon_available_for_current_user << date.strftime("%Y-%m-%d") if Cookoon.available_for(current_user).available_in_day(date).blank?
+      if Cookoon.available_for(current_user).available_in_day(date).blank? || Chef.without_engaged_reservations_in_day(date).blank?
+        @dates_with_no_cookoon_available_for_current_user << date.strftime("%Y-%m-%d")
+      end
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,11 +2,11 @@ class PagesController < ApplicationController
   skip_before_action :authenticate_user!, only: :general_conditions
   before_action :disable_turbolinks_cache, only: :home
   before_action :set_end_date_available, only: :home
-  before_action :set_dates_with_no_cookoon_available_for_current_user, only: :home
+  before_action :set_dates_unavailable, only: :home
 
   def home
     # @reservation = Reservation.new(user: current_user).decorate
-    @reservation = Reservation.new(user: current_user, end_date_available: @end_date_available, dates_with_no_cookoon_available_for_current_user: @dates_with_no_cookoon_available_for_current_user).decorate
+    @reservation = Reservation.new(user: current_user).decorate
   end
 
   def support; end
@@ -19,11 +19,11 @@ class PagesController < ApplicationController
     @end_date_available = ((Date.today + Availability::SETTABLE_WEEKS_AHEAD.weeks).beginning_of_week) - 1.days
   end
 
-  def set_dates_with_no_cookoon_available_for_current_user
-    @dates_with_no_cookoon_available_for_current_user = Array.new
+  def set_dates_unavailable
+    @dates_unavailable = Array.new
     (Date.today..@end_date_available).to_a.each do |date|
       if Cookoon.available_for(current_user).available_in_day(date).blank? || Chef.without_engaged_reservations_in_day(date).blank?
-        @dates_with_no_cookoon_available_for_current_user << date.strftime("%Y-%m-%d")
+        @dates_unavailable << date.strftime("%Y-%m-%d")
       end
     end
   end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -119,7 +119,9 @@ class ReservationsController < ApplicationController
   def set_dates_with_no_cookoon_available_for_current_user
     @dates_with_no_cookoon_available_for_current_user = Array.new
     (Date.today..@end_date_available).to_a.each do |date|
-      @dates_with_no_cookoon_available_for_current_user << date.strftime("%Y-%m-%d") if Cookoon.available_for(current_user).available_in_day(date).blank?
+      if Cookoon.available_for(current_user).available_in_day(date).blank? || Chef.without_engaged_reservations_in_day(date).blank?
+        @dates_with_no_cookoon_available_for_current_user << date.strftime("%Y-%m-%d")
+      end
     end
   end
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -3,7 +3,7 @@ class ReservationsController < ApplicationController
   before_action :find_reservation_with_reservation_id, only: %i[select_cookoon select_menu]
   before_action :find_cookoon, only: %i[select_cookoon]
   before_action :set_end_date_available, only: :new
-  before_action :set_dates_with_no_cookoon_available_for_current_user, only: :new
+  before_action :set_dates_unavailable, only: :new
 
   def index
     # reservations = policy_scope(Reservation).includes(cookoon: :user)
@@ -21,7 +21,7 @@ class ReservationsController < ApplicationController
   end
 
   def new
-    @reservation = Reservation.new(category: params[:category], user: current_user, end_date_available: @end_date_available, dates_with_no_cookoon_available_for_current_user: @dates_with_no_cookoon_available_for_current_user).decorate
+    @reservation = Reservation.new(category: params[:category], user: current_user).decorate
     authorize @reservation
   end
 
@@ -116,11 +116,11 @@ class ReservationsController < ApplicationController
     @end_date_available = ((Date.today + Availability::SETTABLE_WEEKS_AHEAD.weeks).beginning_of_week) - 1.days
   end
 
-  def set_dates_with_no_cookoon_available_for_current_user
-    @dates_with_no_cookoon_available_for_current_user = Array.new
+  def set_dates_unavailable
+    @dates_unavailable = Array.new
     (Date.today..@end_date_available).to_a.each do |date|
       if Cookoon.available_for(current_user).available_in_day(date).blank? || Chef.without_engaged_reservations_in_day(date).blank?
-        @dates_with_no_cookoon_available_for_current_user << date.strftime("%Y-%m-%d")
+        @dates_unavailable << date.strftime("%Y-%m-%d")
       end
     end
   end

--- a/app/frontend/components/search/_search.slim
+++ b/app/frontend/components/search/_search.slim
@@ -21,7 +21,7 @@
           - types.each do |type|
             .input-cookoon-search-selection-item data={type: type[:data], text: type[:display], action: 'click->search#selectType'} #{type[:display]}
 
-      .input-cookoon-search data={target: 'search.dateSelection', 'end-date-available': @end_date_available, 'dates-with-no-cookoon-available': @dates_with_no_cookoon_available_for_current_user}
+      .input-cookoon-search data={target: 'search.dateSelection', 'end-date-available': @end_date_available, 'dates-with-no-cookoon-available': @dates_unavailable}
         p Date
         span.input-cookoon-search-data data={target: 'search.dateText'} = @reservation.default_date
 

--- a/app/frontend/components/search/_search.slim
+++ b/app/frontend/components/search/_search.slim
@@ -21,7 +21,7 @@
           - types.each do |type|
             .input-cookoon-search-selection-item data={type: type[:data], text: type[:display], action: 'click->search#selectType'} #{type[:display]}
 
-      .input-cookoon-search data={target: 'search.dateSelection', 'end-date-available': @end_date_available, 'dates-with-no-cookoon-available': @dates_unavailable}
+      .input-cookoon-search data={target: 'search.dateSelection', 'end-date-available': @end_date_available, 'dates-unavailable': @dates_unavailable}
         p Date
         span.input-cookoon-search-data data={target: 'search.dateText'} = @reservation.default_date
 

--- a/app/frontend/components/search/search_controller.js
+++ b/app/frontend/components/search/search_controller.js
@@ -27,7 +27,7 @@ export default class extends Controller {
     flatpickr(this.dateSelectionTarget, {
       dateFormat: 'Y-m-dTH:i',
       // disable: ["2020-11-30", "2020-12-09"],
-      disable: JSON.parse(this.dateSelectionTarget.getAttribute("data-dates-with-no-cookoon-available")),
+      disable: JSON.parse(this.dateSelectionTarget.getAttribute("data-dates-unavailable")),
       // minDate: 'today',
       minDate: new Date().fp_incr(3),
       maxDate: this.dateSelectionTarget.getAttribute("data-end-date-available"),

--- a/app/models/chef.rb
+++ b/app/models/chef.rb
@@ -2,6 +2,7 @@ class Chef < ApplicationRecord
   has_many :menus
   has_many :chef_perks, dependent: :destroy
   has_many :chef_perk_specifications, through: :chef_perks
+  has_many :reservations, through: :menus
 
   has_attachments :photos, order: 'id ASC'
   has_attachment :main_photo

--- a/app/models/chef.rb
+++ b/app/models/chef.rb
@@ -9,6 +9,14 @@ class Chef < ApplicationRecord
 
   default_scope -> { order(updated_at: :desc) }
 
+  scope :without_engaged_reservations_in_day, -> (day) { where.not(id:
+    Reservation.engaged.joins(:menu).where(
+      'start_at >= ? AND start_at <= ?', day.beginning_of_day, day.end_of_day
+      ).pluck(:menu_id).map {
+      |e| e = Menu.find(e).chef.id
+      }
+    ) }
+
   GENDER = %w[male female]
 
   validates :name, presence: true

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -5,9 +5,6 @@ class Reservation < ApplicationRecord
   include TimeRangeBuilder
   include PriceComputer
 
-  attr_accessor :end_date_available
-  attr_accessor :dates_with_no_cookoon_available_for_current_user
-
   scope :displayable, -> { where.not(aasm_state: :initial).order(start_at: :asc) }
   scope :for_tenant, ->(user) { where(user: user) }
   scope :for_host, ->(user) { where(cookoon: user.cookoons) }

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -59,6 +59,7 @@ class Reservation < ApplicationRecord
   belongs_to :menu, optional: true
   has_many :services, dependent: :destroy
   has_one :inventory, dependent: :destroy
+  has_one :chef, through: :menu
 
   accepts_nested_attributes_for :services
 


### PR DESCRIPTION
- add scope to chef model to check reservations engaged
- update chefs#index to display only chef without reservations on day of reservation
- disable dates in search where there is no chef available