### PR TITLE
Amex cookoon price

### DIFF
--- a/app/models/cookoon.rb
+++ b/app/models/cookoon.rb
@@ -64,6 +64,7 @@ class Cookoon < ApplicationRecord
   enum status: %i[under_review approved suspended]
   geocoded_by :address
   monetize :price_cents
+  monetize :amex_price_cents
 
   validates :name,     presence: true
   validates :citation, presence: true

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -11,7 +11,7 @@ class Menu < ApplicationRecord
   monetize :unit_price_cents
 
   validates :description, presence: true
-  validates :unit_price, presence: true, numericality: { greater_than: 0 }
+  validates :unit_price, presence: true, numericality: { greater_than: 0 }, unless: :amex?
   validates :status, presence: true, inclusion: { in: Menu::STATUSES }
   validates :meal_type, presence: true, inclusion: { in: Menu::MEAL_TYPES.keys }
 

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -186,13 +186,13 @@ class Reservation < ApplicationRecord
 
   def notify_users_after_amex_asking
     ReservationMailer.amex_request_to_tenant(self).deliver_later
-    # ReservationMailer.amex_request_to_host(self).deliver_later
+    ReservationMailer.amex_request_to_host(self).deliver_later
     ReservationMailer.amex_request_to_amex(self).deliver_later
   end
 
   def notify_users_after_amex_host_confirmation
     ReservationMailer.amex_host_confirmation_to_tenant(self).deliver_later
-    # ReservationMailer.amex_host_confirmation_to_host(self).deliver_later
+    ReservationMailer.amex_host_confirmation_to_host(self).deliver_later
   end
 
   def notify_users_after_quotation_host_confirmation

--- a/app/models/reservation/price_computer.rb
+++ b/app/models/reservation/price_computer.rb
@@ -59,7 +59,11 @@ class Reservation
     def compute_cookoon_price
       return 0 unless duration.present? && cookoon.present?
 
-      cookoon_price_cents = duration * cookoon.price
+      if amex?
+        cookoon_price_cents = cookoon.amex_price
+      else
+        cookoon_price_cents = duration * cookoon.price
+      end
       # if customer? && duration > 4
       #   # discount applied
       #   cookoon_price_cents = cookoon_price_cents  * 0.85

--- a/db/migrate/20201215144108_add_amex_price_cents_to_cookoons.rb
+++ b/db/migrate/20201215144108_add_amex_price_cents_to_cookoons.rb
@@ -1,0 +1,5 @@
+class AddAmexPriceCentsToCookoons < ActiveRecord::Migration[5.2]
+  def change
+    add_column :cookoons, :amex_price_cents, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_11_154138) do
+ActiveRecord::Schema.define(version: 2020_12_15_144108) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -134,6 +134,7 @@ ActiveRecord::Schema.define(version: 2020_12_11_154138) do
     t.string "architect_title"
     t.string "architect_url"
     t.boolean "amex", default: false
+    t.integer "amex_price_cents", default: 0
     t.index ["user_id"], name: "index_cookoons_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -95,7 +95,8 @@ cookoons_attributes = [
     architect_title: "Architecte - décorateur",
     architect_build_year: 2020,
     architect_url: "htpps://membre.cookoon.club",
-    amex: true
+    amex: true,
+    amex_price: 1000,
   },
   {
     user: User.first,
@@ -166,7 +167,8 @@ cookoons_attributes = [
     long_photo_url: "https://images.unsplash.com/photo-1502005229762-cf1b2da7c5d6?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60",
     main_photo_url: "https://images.unsplash.com/photo-1559310278-18a9192d909f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60",
     citation: "Un espace vivant",
-    amex: true
+    amex: true,
+    amex_price: 1500
   },
 ]
 
@@ -251,7 +253,7 @@ menu_attributes = [
   {
     chef: Chef.first,
     status: "amex",
-    unit_price_cents: 3000,
+    unit_price_cents: 0,
     description: "Menu Amex I",
     meal_type: "seated_meal"
   },
@@ -286,7 +288,7 @@ menu_attributes = [
   {
     chef: Chef.last,
     status: "amex",
-    unit_price_cents: 5000,
+    unit_price_cents: 0,
     description: "Menu Amex II",
     meal_type: "seated_meal"
   },

--- a/spec/concerns/reservation/price_computer_spec.rb
+++ b/spec/concerns/reservation/price_computer_spec.rb
@@ -10,10 +10,14 @@ RSpec.describe Reservation::PriceComputer do
     let!(:service) { create(:service, reservation: reservation, category: 'corporate', status: 'validated') }
     let(:prices) { reservation.computed_price_attributes }
 
-    let(:cookoon_a) { create(:cookoon, price_cents: 3000) }
-    let(:chef_a) { create(:chef, base_price_cents: 0, min_price_cents: 200000) }
+    # let(:cookoon_a) { create(:cookoon, price_cents: 3000) }
+    let(:cookoon_a) { create(:cookoon, price_cents: 3000, amex: true, amex_price_cents: 500000) }
+    # let(:chef_a) { create(:chef, base_price_cents: 0, min_price_cents: 200000) }
+    let(:chef_a) { create(:chef, base_price_cents: 0, min_price_cents: 200000, amex: true) }
     let(:menu_a) { create(:menu, chef: chef_a, unit_price_cents: 2500) }
+    let(:menu_amex) { create(:menu, chef: chef_a, status: 'amex', unit_price_cents: 0) }
     let(:reservation_a) { create(:reservation, cookoon: cookoon_a, people_count: 2, type_name: 'lunch_cocktail', category: 'customer', menu: menu_a) }
+    let(:reservation_amex) { create(:reservation, cookoon: cookoon_a, people_count: 2, type_name: 'amex_diner', category: 'amex', menu: menu_amex) }
     let!(:service_a_a) { create(:service, reservation: reservation_a, category: 'sommelier') }
     let!(:service_a_b) { create(:service, reservation: reservation_a, category: 'parking') }
     let!(:service_a_f) { create(:service, reservation: reservation_a, category: 'flowers') }
@@ -21,6 +25,7 @@ RSpec.describe Reservation::PriceComputer do
     let!(:service_a_h) { create(:service, reservation: reservation_a, category: 'wine') }
     let!(:service_a_o) { create(:service, reservation: reservation_a, category: 'wine') }
     let(:prices_a) { reservation_a.computed_price_attributes }
+    let(:prices_amex) { reservation_amex.computed_price_attributes }
 
     # it 'prints the instances' do
     #   puts reservation.class.to_s.upcase
@@ -39,6 +44,7 @@ RSpec.describe Reservation::PriceComputer do
     it 'returns a Hash' do
       expect(prices).to be_a(Hash)
       expect(prices_a).to be_a(Hash)
+      expect(prices_amex).to be_a(Hash)
     end
 
     it 'computes cookoon_price' do
@@ -47,6 +53,7 @@ RSpec.describe Reservation::PriceComputer do
       # puts prices[:cookoon][:cookoon_price]
       expect(prices[:cookoon][:cookoon_price]).to eq(Money.new 27000, 'EUR')
       expect(prices_a[:cookoon][:cookoon_price]).to eq(Money.new 15000, 'EUR')
+      expect(prices_amex[:cookoon][:cookoon_price]).to eq(Money.new 500000, 'EUR')
     end
 
     it 'computes butler_price' do
@@ -54,6 +61,7 @@ RSpec.describe Reservation::PriceComputer do
       # puts prices[:butler][:butler_price]
       expect(prices[:butler][:butler_price]).to eq(Money.new 26250, 'EUR')
       expect(prices_a[:butler][:butler_price]).to eq(Money.new 21875, 'EUR')
+      expect(prices_amex[:butler][:butler_price]).to eq(Money.new 0, 'EUR')
     end
 
     it 'computes cookoon_butler_price for duration' do
@@ -62,6 +70,7 @@ RSpec.describe Reservation::PriceComputer do
       # puts prices[:cookoon_butler][:cookoon_butler_price]
       expect(prices[:cookoon_butler][:cookoon_butler_price]).to eq(Money.new 53250, 'EUR')
       expect(prices_a[:cookoon_butler][:cookoon_butler_price]).to eq(Money.new 36875, 'EUR')
+      expect(prices_amex[:cookoon_butler][:cookoon_butler_price]).to eq(Money.new 500000, 'EUR')
     end
 
     it 'computes menu_price' do
@@ -70,6 +79,7 @@ RSpec.describe Reservation::PriceComputer do
       # puts prices[:menu][:menu_price]
       expect(prices[:menu][:menu_price]).to eq(Money.new 0, 'EUR')
       expect(prices_a[:menu][:menu_price]).to eq(Money.new 230000, 'EUR')
+      expect(prices_amex[:menu][:menu_price]).to eq(Money.new 230000, 'EUR')
     end
 
     it 'computes services_price' do
@@ -77,6 +87,7 @@ RSpec.describe Reservation::PriceComputer do
       # puts prices[:services][:services_price]
       expect(prices[:services][:services_price]).to eq(Money.new 27500, 'EUR')
       expect(prices_a[:services][:services_price]).to eq(Money.new 46875, 'EUR')
+      expect(prices_amex[:services][:services_price]).to eq(Money.new 0, 'EUR')
     end
 
     it 'computes total_price' do
@@ -86,28 +97,32 @@ RSpec.describe Reservation::PriceComputer do
       # puts prices[:total][:total_price]
       expect(prices[:total][:total_price]).to eq(Money.new 80750, 'EUR')
       expect(prices_a[:total][:total_price]).to eq(Money.new 313750, 'EUR')
-
+      expect(prices_amex[:total][:total_price]).to eq(Money.new 730000, 'EUR')
     end
 
     it 'computes butler_tax' do
       # puts prices[:butler][:butler_price] * 0.2
       expect(prices[:butler][:butler_tax]).to eq(Money.new 5250, 'EUR')
       expect(prices_a[:butler][:butler_tax]).to eq(Money.new 4375, 'EUR')
+      expect(prices_amex[:butler][:butler_tax]).to eq(Money.new 0, 'EUR')
     end
 
     it 'computes cookoon_butler_tax' do
       expect(prices[:cookoon_butler][:cookoon_butler_tax]).to eq(Money.new 5250, 'EUR')
       expect(prices_a[:cookoon_butler][:cookoon_butler_tax]).to eq(Money.new 4375, 'EUR')
+      expect(prices_amex[:cookoon_butler][:cookoon_butler_tax]).to eq(Money.new 0, 'EUR')
     end
 
     it 'computes menu_tax' do
       expect(prices[:menu][:menu_tax]).to eq(Money.new 0, 'EUR')
       expect(prices_a[:menu][:menu_tax]).to eq(Money.new 46000, 'EUR')
+      expect(prices_amex[:menu][:menu_tax]).to eq(Money.new 46000, 'EUR')
     end
 
     it 'computes services_tax' do
       expect(prices[:services][:services_tax]).to eq(Money.new 5500, 'EUR')
       expect(prices_a[:services][:services_tax]).to eq(Money.new 9375, 'EUR')
+      expect(prices_amex[:services][:services_tax]).to eq(Money.new 0, 'EUR')
     end
 
     it 'computes total_tax' do
@@ -117,6 +132,7 @@ RSpec.describe Reservation::PriceComputer do
       # puts prices[:total][:total_tax]
       expect(prices[:total][:total_tax]).to eq(Money.new 10750, 'EUR')
       expect(prices_a[:total][:total_tax]).to eq(Money.new 59750, 'EUR')
+      expect(prices_amex[:total][:total_tax]).to eq(Money.new 46000, 'EUR')
     end
 
     it 'computes butler_with_tax' do
@@ -126,28 +142,33 @@ RSpec.describe Reservation::PriceComputer do
       # puts prices[:butler][:butler_with_tax]
       expect(prices[:butler][:butler_with_tax]).to eq(Money.new 31500, 'EUR')
       expect(prices_a[:butler][:butler_with_tax]).to eq(Money.new 26250, 'EUR')
+      expect(prices_amex[:butler][:butler_with_tax]).to eq(Money.new 0, 'EUR')
     end
 
     it 'computes cookoon_butler_with_tax' do
       expect(prices[:cookoon_butler][:cookoon_butler_with_tax]).to eq(Money.new 58500, 'EUR')
       expect(prices_a[:cookoon_butler][:cookoon_butler_with_tax]).to eq(Money.new 41250, 'EUR')
+      expect(prices_amex[:cookoon_butler][:cookoon_butler_with_tax]).to eq(Money.new 500000, 'EUR')
     end
 
     it 'computes menu_with_tax' do
       expect(prices[:menu][:menu_with_tax]).to eq(Money.new 0, 'EUR')
       expect(prices_a[:menu][:menu_with_tax]).to eq(Money.new 276000, 'EUR')
+      expect(prices_amex[:menu][:menu_with_tax]).to eq(Money.new 276000, 'EUR')
     end
 
     it 'computes services_with_tax' do
       # puts prices[:services]
       expect(prices[:services][:services_with_tax]).to eq(Money.new 33000, 'EUR')
       expect(prices_a[:services][:services_with_tax]).to eq(Money.new 56250, 'EUR')
+      expect(prices_amex[:services][:services_with_tax]).to eq(Money.new 0, 'EUR')
     end
 
     it 'computes total_with_tax' do
       # puts prices[:total]
       expect(prices[:total][:total_with_tax]).to eq(Money.new 91500, 'EUR')
       expect(prices_a[:total][:total_with_tax]).to eq(Money.new 373500, 'EUR')
+      expect(prices_amex[:total][:total_with_tax]).to eq(Money.new 776000, 'EUR')
     end
   end
 end


### PR DESCRIPTION
- add amex_price to cookoons
- authorize amex menus to have unit_price of 0 euros
- update seed and tests for price computer