### PR TITLE
Prices for services

### DIFF
--- a/app/controllers/chefs_controller.rb
+++ b/app/controllers/chefs_controller.rb
@@ -23,9 +23,9 @@ class ChefsController < ApplicationController
 
   def show
     if @reservation.seated?
-      @menus = @chef.menus.includes(:dishes).active.seated.order_by_asc_price
+      @menus = MenuDecorator.decorate_collection(@chef.menus.includes(:dishes).active.seated.order_by_asc_price)
     elsif @reservation.standing?
-      @menus = @chef.menus.includes(:dishes).active.standing.order_by_asc_price
+      @menus = MenuDecorator.decorate_collection(@chef.menus.includes(:dishes).active.standing.order_by_asc_price)
     end
   end
 

--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -1,0 +1,7 @@
+class ServiceDecorator < Draper::Decorator
+  delegate_all
+
+  def full_price
+    h.humanized_money_with_symbol object.price_with_tax
+  end
+end

--- a/app/models/reservation/price_computer.rb
+++ b/app/models/reservation/price_computer.rb
@@ -99,9 +99,7 @@ class Reservation
     end
 
     def compute_services_price
-      # return 0 unless services.present?
-      Money.new(services.where.not(status: "initial").pluck(:price_cents).sum)
-      # Money.new(services.pluck(:price_cents).sum)
+      set_ht(compute_services_with_tax)
     end
 
     def compute_total_price
@@ -169,7 +167,7 @@ class Reservation
     end
 
     def compute_services_with_tax
-      [compute_services_price, compute_services_tax].sum
+      Money.new(services.where.not(status: "initial").map { |service| service.price_with_tax_cents }.sum)
     end
 
     def compute_total_with_tax

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,4 +1,6 @@
 class Service < ApplicationRecord
+  include PriceComputer
+
   belongs_to :reservation
 
   scope :payment_tied_to_reservation, -> { where(payment_tied_to_reservation: true) }
@@ -32,10 +34,6 @@ class Service < ApplicationRecord
 
   def payment(options = {})
     Service::Payment.new(self, options)
-  end
-
-  def price_with_margin_and_taxes
-    calculate_price_with_margin_and_taxes
   end
 
   def validate!
@@ -156,15 +154,6 @@ class Service < ApplicationRecord
     category == "wine"
   end
 
-  def compute_price
-    # self.price = (1 + self.margin) * ((self.quantity_base * self.base_price) + (self.quantity * self.unit_price))
-    assign_attributes(price: (1 + margin) * ((quantity_base * base_price) + (quantity * unit_price)))
-  end
-
-  def calculate_price_with_margin_and_taxes
-    price * (1 + Reservation::PriceComputer::TAX )
-  end
-
   def price_fixed?
     CATEGORIES_WITH_FIXED_PRICE.include?(category)
   end
@@ -172,7 +161,6 @@ class Service < ApplicationRecord
   def set_status_validated_for_categories_with_fixed_price
     assign_attributes(status: 'validated') if price_fixed?
   end
-
 end
 
 # class Service < ApplicationRecord

--- a/app/models/service/price_computer.rb
+++ b/app/models/service/price_computer.rb
@@ -3,7 +3,11 @@ class Service
     extend ActiveSupport::Concern
 
     def price_with_tax
-      (1 + Reservation::TAX) * price
+      price_with_tax_cents / 100
+    end
+
+    def price_with_tax_cents
+      (price_with_tax_cents_without_rounding / 5).ceil(-2) * 5
     end
 
     private
@@ -14,10 +18,6 @@ class Service
 
     def price_with_tax_cents_without_rounding
       (1 + Reservation::TAX) * (1 + margin) * ((quantity_base * base_price_cents) + (quantity * unit_price_cents))
-    end
-
-    def price_with_tax_cents
-      (price_with_tax_cents_without_rounding / 5).ceil(-2) * 5
     end
   end
 end

--- a/app/models/service/price_computer.rb
+++ b/app/models/service/price_computer.rb
@@ -1,0 +1,23 @@
+class Service
+  module PriceComputer
+    extend ActiveSupport::Concern
+
+    def price_with_tax
+      (1 + Reservation::TAX) * price
+    end
+
+    private
+
+    def compute_price
+      assign_attributes(price_cents: price_with_tax_cents / (1 + Reservation::TAX))
+    end
+
+    def price_with_tax_cents_without_rounding
+      (1 + Reservation::TAX) * (1 + margin) * ((quantity_base * base_price_cents) + (quantity * unit_price_cents))
+    end
+
+    def price_with_tax_cents
+      (price_with_tax_cents_without_rounding / 5).ceil(-2) * 5
+    end
+  end
+end

--- a/app/views/admin/reservations/show.html.erb
+++ b/app/views/admin/reservations/show.html.erb
@@ -61,14 +61,14 @@
 
         <h3 class="mt-3">Services</h3>
         <% if @reservation.services.present? %>
-          <% @reservation.services.each do |service| %>
+          <% ServiceDecorator.decorate_collection(@reservation.services).each do |service| %>
             <div class="mb-5">
               <p><%= service.name %></p>
               <p>Statut: <%= service.status %></p>
               <p>Tarif: <%= service.quantity %> x <%= service.unit_price %></p>
               <p>Frais de service: <%= service.quantity_base %> x <%= service.base_price %></p>
               <p>Marge: <%= service.margin %></p>
-              <p>Total HT avec marge: <%= service.price %></p>
+              <p>Total avec marge: <%= service.full_price %>TTC</p>
               <% if @reservation.accepts_new_service? && service.initial? %>
                 <%= link_to 'Modifier', edit_admin_reservation_service_path(@reservation, service), :class => "btn-cookoon btn-cookoon-primary mb-4" %>
                 <%= link_to 'Valider', admin_reservation_service_validate_service_path(@reservation, service), method: :patch, :class => "btn-cookoon btn-cookoon-primary mb-4" %>

--- a/app/views/admin/reservations/show.html.erb
+++ b/app/views/admin/reservations/show.html.erb
@@ -54,7 +54,7 @@
             <strong>Chef: </strong>
             <%= @reservation.menu.chef.name %>
           </p>
-          <%= render 'menus/card', menu: @reservation.menu, chef: @reservation.menu.chef, reservation: @reservation %>
+          <%= render 'menus/card', menu: @reservation.menu.decorate, chef: @reservation.menu.chef, reservation: @reservation %>
         <% else %>
           <p>Aucun menu n'a été sélectionné</p>
         <% end %>

--- a/app/views/menus/_card.slim
+++ b/app/views/menus/_card.slim
@@ -10,7 +10,7 @@
       '*****
   .menu-card-price
     .text-primary.mb-2 Prix:
-    p.mb-0 #{menu.decorate.full_price_per_person_without_cents(reservation.people_count)}TTC par convive
+    p.mb-0 #{menu.full_price_per_person_without_cents(reservation.people_count)}TTC par convive
     p.mb-3 pour #{reservation.people_count} convives
     small.text-primary.font-italic.align-left Ce tarif inclut la présence du chef, sa prestation et le menu
 

--- a/app/views/payments/_details_services.slim
+++ b/app/views/payments/_details_services.slim
@@ -4,7 +4,7 @@ p.mb-3.font-weight-bold 3. Vos souhaits de service
 - if reservation.services.present?
   .mb-4
     p.font-weight-bold Troisième règlement
-    - reservation.services.each do |service|
+    - ServiceDecorator.decorate_collection(reservation.services).each do |service|
       .d-flex.justify-content-between
         p.mb-1
           '- &nbsp
@@ -12,8 +12,7 @@ p.mb-3.font-weight-bold 3. Vos souhaits de service
         - if service.status == "initial"
           p.mb-1.text-right = Payment::STATUSES[:quotation_asked]
         - else
-          p.mb-1.text-right #{humanized_money_with_symbol(service.price_with_margin_and_taxes)}TTC
-
+          p.mb-1.text-right #{service.decorate.full_price}TTC
 
   .mb-4
     - if reservation.pending? || reservation.charged? || reservation.accepted? || reservation.menu_payment_captured?

--- a/spec/concerns/reservation/price_computer_spec.rb
+++ b/spec/concerns/reservation/price_computer_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Reservation::PriceComputer do
       # puts reservation.services.pluck(:price_cents) unless reservation.services.nil?
       # puts prices[:services][:services_price]
       expect(prices[:services][:services_price]).to eq(Money.new 27500, 'EUR')
-      expect(prices_a[:services][:services_price]).to eq(Money.new 46875, 'EUR')
+      expect(prices_a[:services][:services_price]).to eq(Money.new 47083, 'EUR')
       expect(prices_amex[:services][:services_price]).to eq(Money.new 0, 'EUR')
       expect(prices_amex_b[:services][:services_price]).to eq(Money.new 0, 'EUR')
     end
@@ -112,7 +112,7 @@ RSpec.describe Reservation::PriceComputer do
       # puts prices[:services][:services_price]
       # puts prices[:total][:total_price]
       expect(prices[:total][:total_price]).to eq(Money.new 80750, 'EUR')
-      expect(prices_a[:total][:total_price]).to eq(Money.new 313958, 'EUR')
+      expect(prices_a[:total][:total_price]).to eq(Money.new 314166, 'EUR')
       expect(prices_amex[:total][:total_price]).to eq(Money.new 106000, 'EUR')
       expect(prices_amex_b[:total][:total_price]).to eq(Money.new 106000, 'EUR')
     end
@@ -141,7 +141,7 @@ RSpec.describe Reservation::PriceComputer do
 
     it 'computes services_tax' do
       expect(prices[:services][:services_tax]).to eq(Money.new 5500, 'EUR')
-      expect(prices_a[:services][:services_tax]).to eq(Money.new 9375, 'EUR')
+      expect(prices_a[:services][:services_tax]).to eq(Money.new 9417, 'EUR')
       expect(prices_amex[:services][:services_tax]).to eq(Money.new 0, 'EUR')
       expect(prices_amex_b[:services][:services_tax]).to eq(Money.new 0, 'EUR')
     end
@@ -152,7 +152,7 @@ RSpec.describe Reservation::PriceComputer do
       # puts prices[:services][:services_tax]
       # puts prices[:total][:total_tax]
       expect(prices[:total][:total_tax]).to eq(Money.new 10750, 'EUR')
-      expect(prices_a[:total][:total_tax]).to eq(Money.new 59792, 'EUR')
+      expect(prices_a[:total][:total_tax]).to eq(Money.new 59834, 'EUR')
       expect(prices_amex[:total][:total_tax]).to eq(Money.new 14000, 'EUR')
       expect(prices_amex_b[:total][:total_tax]).to eq(Money.new 14000, 'EUR')
     end
@@ -185,7 +185,7 @@ RSpec.describe Reservation::PriceComputer do
     it 'computes services_with_tax' do
       # puts prices[:services]
       expect(prices[:services][:services_with_tax]).to eq(Money.new 33000, 'EUR')
-      expect(prices_a[:services][:services_with_tax]).to eq(Money.new 56250, 'EUR')
+      expect(prices_a[:services][:services_with_tax]).to eq(Money.new 56500, 'EUR')
       expect(prices_amex[:services][:services_with_tax]).to eq(Money.new 0, 'EUR')
       expect(prices_amex_b[:services][:services_with_tax]).to eq(Money.new 0, 'EUR')
     end
@@ -193,7 +193,7 @@ RSpec.describe Reservation::PriceComputer do
     it 'computes total_with_tax' do
       # puts prices[:total]
       expect(prices[:total][:total_with_tax]).to eq(Money.new 91500, 'EUR')
-      expect(prices_a[:total][:total_with_tax]).to eq(Money.new 373750, 'EUR')
+      expect(prices_a[:total][:total_with_tax]).to eq(Money.new 374000, 'EUR')
       expect(prices_amex[:total][:total_with_tax]).to eq(Money.new 120000, 'EUR')
       expect(prices_amex_b[:total][:total_with_tax]).to eq(Money.new 120000, 'EUR')
     end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Service, type: :model do
 
     puts "Test création des services pour un dîner de #{@reservation.people_count} personnes"
 
-    @results = { service_special_price_cents: 0, service_sommelier_price_cents: 31250, service_parking_price_cents: 61875, service_corporate_price_cents: 27500, service_catering_price_cents: 37500, service_breakfast_price_cents: 51000, service_flowers_price_cents: 22500, service_wine_price_cents: 7500 }
+    @results = { service_special_price_cents: 0, service_sommelier_price_cents: 31250, service_parking_price_cents: 62083, service_corporate_price_cents: 27500, service_catering_price_cents: 37500, service_breakfast_price_cents: 51250, service_flowers_price_cents: 22500, service_wine_price_cents: 7500 }
 
     test_the_services_prices # method in spec/support/service_helpers
   end
@@ -35,7 +35,7 @@ RSpec.describe Service, type: :model do
 
     puts "Test création des services pour un dîner de #{@reservation.people_count} personnes"
 
-    @results = { service_special_price_cents: 0, service_sommelier_price_cents: 62500, service_parking_price_cents: 114375, service_corporate_price_cents: 50000, service_catering_price_cents: 84375, service_breakfast_price_cents: 105000, service_flowers_price_cents: 22500, service_wine_price_cents: 7500 }
+    @results = { service_special_price_cents: 0, service_sommelier_price_cents: 62500, service_parking_price_cents: 114583, service_corporate_price_cents: 50000, service_catering_price_cents: 84583, service_breakfast_price_cents: 105000, service_flowers_price_cents: 22500, service_wine_price_cents: 7500 }
 
     test_the_services_prices # method in spec/support/service_helpers
   end
@@ -46,7 +46,7 @@ RSpec.describe Service, type: :model do
 
     puts "Test création des services pour un dîner de #{@reservation.people_count} personnes"
 
-    @results = { service_special_price_cents: 0, service_sommelier_price_cents: 31250, service_parking_price_cents: 61875, service_corporate_price_cents: 15500, service_catering_price_cents: 12500, service_breakfast_price_cents: 22200, service_flowers_price_cents: 22500, service_wine_price_cents: 7500 }
+    @results = { service_special_price_cents: 0, service_sommelier_price_cents: 31250, service_parking_price_cents: 62083, service_corporate_price_cents: 15833, service_catering_price_cents: 12500, service_breakfast_price_cents: 22500, service_flowers_price_cents: 22500, service_wine_price_cents: 7500 }
 
     test_the_services_prices # method in spec/support/service_helpers
   end
@@ -57,7 +57,7 @@ RSpec.describe Service, type: :model do
 
     puts "Test création des services pour un dîner de #{@reservation.people_count} personnes"
 
-    @results = { service_special_price_cents: 0, service_sommelier_price_cents: 218750, service_parking_price_cents: 481875, service_corporate_price_cents: 200000, service_catering_price_cents: 396875, service_breakfast_price_cents: 465000, service_flowers_price_cents: 22500, service_wine_price_cents: 7500 }
+    @results = { service_special_price_cents: 0, service_sommelier_price_cents: 218750, service_parking_price_cents: 482083, service_corporate_price_cents: 200000, service_catering_price_cents: 397083, service_breakfast_price_cents: 465000, service_flowers_price_cents: 22500, service_wine_price_cents: 7500 }
 
     test_the_services_prices # method in spec/support/service_helpers
   end


### PR DESCRIPTION
- add price_computer for services
- remove class method relating to price calculation in service model as they have been transfered in service price_computer
- add service decorator and use it in reservation payment page + admin reservation show

Others
- decorate menus in chef_controller#show instead of doing it in menu_card
- decorate menu in admin reservation show
- update tests reservation price_computer_spec.rb + spec/models/service_spec.rb